### PR TITLE
Fix: Global Sticky Nav behavior with a few components

### DIFF
--- a/src/Theme.re
+++ b/src/Theme.re
@@ -37,6 +37,13 @@ module MediaQuery = {
   let mobile = "(max-width:48rem)";
 };
 
+module StackingIndex = {
+  let zHide = (-100);
+  let zNav = 100;
+  let zContent = 200;
+  let zModal = 1000;
+};
+
 type backgroundImage = {
   desktop: string,
   tablet: string,

--- a/src/components/Contributors.re
+++ b/src/components/Contributors.re
@@ -21,7 +21,7 @@ module Styles = {
       top(`percent(50.)),
       left(`percent(50.)),
       transform(`translate((`percent(-50.), `percent(-50.)))),
-      zIndex(2),
+      zIndex(Theme.StackingIndex.zModal),
     ]);
 
   let modal = style([margin(`auto)]);

--- a/src/components/CookieWarning.re
+++ b/src/components/CookieWarning.re
@@ -29,6 +29,7 @@ module Styles = {
       background(Theme.Colors.digitalBlack),
       boxSizing(`borderBox),
       boxShadow(~x=`px(0), ~y=`px(1), `hex("e5e5e5e5")),
+      zIndex(Theme.StackingIndex.zContent),
       media(
         Theme.MediaQuery.notMobile,
         [

--- a/src/components/Dropdown.re
+++ b/src/components/Dropdown.re
@@ -46,7 +46,7 @@ module Styles = {
         borderRadius(`px(4)),
         pointerEvents(`auto),
         opacity(1.),
-        zIndex(100),
+        zIndex(Theme.StackingIndex.zContent),
         selector(
           "li",
           [

--- a/src/components/FeaturedSingleRow.re
+++ b/src/components/FeaturedSingleRow.re
@@ -112,6 +112,7 @@ module SingleRow = {
         justifyContent(`spaceBetween),
         padding(`rem(2.)),
         backgroundSize(`cover),
+        zIndex(Theme.StackingIndex.zContent),
         media(
           Theme.MediaQuery.notMobile,
           [

--- a/src/components/FeaturedSingleRowFull.re
+++ b/src/components/FeaturedSingleRowFull.re
@@ -71,7 +71,7 @@ module Styles = {
 
   let contentBlock = (contentBackground: Row.backgroundType) => {
     style([
-      zIndex(100),
+      zIndex(Theme.StackingIndex.zContent),
       width(`percent(100.)),
       maxHeight(`rem(35.)),
       overflow(`scroll),

--- a/src/components/Leaderboard.re
+++ b/src/components/Leaderboard.re
@@ -221,7 +221,7 @@ module Styles = {
         backgroundColor(Theme.Colors.digitalBlack),
         color(white),
         top(`zero),
-        zIndex(99),
+        zIndex(Theme.StackingIndex.zContent),
         display(`none),
         paddingBottom(`rem(0.5)),
         fontSize(`rem(0.875)),

--- a/src/components/Nav.re
+++ b/src/components/Nav.re
@@ -11,7 +11,7 @@ module Styles = {
       height(`rem(4.25)),
       marginBottom(`rem(-4.25)),
       width(`percent(100.)),
-      zIndex(100),
+      zIndex(Theme.StackingIndex.zContent),
       media(
         Theme.MediaQuery.tablet,
         [

--- a/src/components/WorldMapSection.re
+++ b/src/components/WorldMapSection.re
@@ -58,7 +58,7 @@ module Styles = {
       bottom(`zero),
       right(`rem(35.5)),
       height(`rem(9.375)),
-      zIndex(99),
+      zIndex(Theme.StackingIndex.zContent),
       width(`rem(8.375)),
       display(`none),
       media(Theme.MediaQuery.desktop, [display(`grid)]),

--- a/src/pages/Grants.re
+++ b/src/pages/Grants.re
@@ -41,7 +41,7 @@ module Styles = {
       top(sticky ? `rem(3.5) : `rem(107.)),
       marginLeft(`calc((`sub, `vw(50.), `rem(71. /. 2.)))),
       width(`rem(14.)),
-      zIndex(100),
+      zIndex(Theme.StackingIndex.zNav),
       background(white),
       media(Theme.MediaQuery.desktop, [display(`block)]),
     ]);

--- a/src/pages/LeaderboardPage.re
+++ b/src/pages/LeaderboardPage.re
@@ -114,7 +114,7 @@ module ToggleButtons = {
           borderTopRightRadius(`px(1)),
           borderBottomLeftRadius(`px(1)),
           border(`px(1), `solid, Theme.Colors.digitalBlack),
-          zIndex(100),
+          zIndex(Theme.StackingIndex.zNav),
           selector(
             "*:not(:last-child)",
             [borderRight(`px(1), `solid, Theme.Colors.digitalBlack)],
@@ -132,7 +132,7 @@ module ToggleButtons = {
             borderBottomLeftRadius(`px(1)),
             border(`px(1), `solid, black),
             transform(translateZ(`px(-1))),
-            zIndex(-99),
+            zIndex(Theme.StackingIndex.zHide),
           ]),
         ]),
       ]);

--- a/src/pages/NodeOperators.re
+++ b/src/pages/NodeOperators.re
@@ -7,7 +7,7 @@ module Styles = {
       top(sticky ? `rem(3.5) : `rem(66.)),
       marginLeft(`calc((`sub, `vw(50.), `rem(71. /. 2.)))),
       width(`rem(14.)),
-      zIndex(100),
+      zIndex(Theme.StackingIndex.zContent),
       background(white),
       marginTop(`rem(3.5)),
       media(Theme.MediaQuery.desktop, [display(`block)]),
@@ -361,7 +361,7 @@ let make = () => {
         Theme.mobile: "/static/img/backgrounds/NodeOperatorHeroMobile.jpg",
       }
       title="Get Started For Node Operators"
-      header=Some("Run a Node")
+      header={Some("Run a Node")}
       copy={
         Some(
           {js|With the world’s lightest blockchain, running a node is easier than ever. Here you’ll find everything you need to get up and running.|js},

--- a/src/pages/Tech.re
+++ b/src/pages/Tech.re
@@ -32,7 +32,7 @@ module Styles = {
       top(sticky ? `rem(3.5) : `rem(66.)),
       marginLeft(`calc((`sub, `vw(50.), `rem(71. /. 2.)))),
       width(`rem(14.)),
-      zIndex(100),
+      zIndex(Theme.StackingIndex.zNav),
       background(white),
       media(Theme.MediaQuery.desktop, [display(`block)]),
     ]);


### PR DESCRIPTION
This PR addresses the issue with the NavBar behind on top of some content components that we want to show. Added a StackingIndex module to `Theme.re` that will contain the zIndex info across the website. 

Addresses the following notion item:
https://www.notion.so/minaprotocol/758496b5f1394885871eadf472a9d8e6?v=73569638cc654494ba5a5cb23e57e8b0&p=d43a95c5be844fabadffc72863106216