### PR TITLE
Hotfix: Add CTA's to Testnet Retro Module

### DIFF
--- a/src/components/ListModule.re
+++ b/src/components/ListModule.re
@@ -62,6 +62,11 @@ let renderInternalLinkKind = (itemKind, slug, inner) => {
     <Next.Link href="/blog/[slug]" _as={"/blog/" ++ slug} passHref=true>
       inner
     </Next.Link>
+  | TestnetRetro =>
+    /* TODO: TestnetRetros should have their own URL and not carry off of blog*/
+    <Next.Link href="/blog/[slug]" _as={"/blog/" ++ slug} passHref=true>
+      inner
+    </Next.Link>
   | Announcement =>
     <Next.Link
       href="/announcements/[slug]"


### PR DESCRIPTION
This PR adds a CTA label for available testnet retro listings. This is currently a hotfix and a work around as the CTA's link to a blog detail page. These listings should eventually have their own URL. 

![image](https://user-images.githubusercontent.com/9512405/101224311-14868100-3643-11eb-9e9f-29cba62e954b.png)
