### PR TITLE
Path wrong for macOS setup

### DIFF
--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -22,7 +22,7 @@ Use [Homebrew](https://brew.sh/) to update the `mina` package.
 
 ```
 brew upgrade mina
-wget -O ~/.coda_config/daemon.json https://raw.githubusercontent.com/MinaProtocol/coda-automation/master/terraform/testnets/turbo-pickles/genesis_ledger.json
+wget -O ~/.coda-config/daemon.json https://raw.githubusercontent.com/MinaProtocol/coda-automation/master/terraform/testnets/turbo-pickles/genesis_ledger.json
 ```
 
 Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]60c98f961a50d93ea79ab465370d0bf3e886acf1 on branch HEAD`.


### PR DESCRIPTION
Does not match rest of docs. Will fail to find the right file when you start the node (unless you override the path, but docs doesn't indicate this)