### PR TITLE
Hotfix: Fix sizing of Hero component height 

### DIFF
--- a/src/components/Hero.re
+++ b/src/components/Hero.re
@@ -1,9 +1,12 @@
 open Css;
 
 module Styles = {
-  let heroContainer = (backgroundImg: Theme.backgroundImage) =>
+  let heroContainer = (backgroundImg: Theme.backgroundImage, contentSize) =>
     style([
-      height(`rem(37.)),
+      switch (contentSize) {
+      | `Large => height(`percent(100.))
+      | `Small => height(`rem(37.))
+      },
       display(`flex),
       flexDirection(`column),
       justifyContent(`flexEnd),
@@ -14,7 +17,10 @@ module Styles = {
         Theme.MediaQuery.tablet,
         [
           justifyContent(`flexStart),
-          height(`rem(47.)),
+          switch (contentSize) {
+          | `Large => height(`percent(100.))
+          | `Small => height(`rem(47.))
+          },
           backgroundImage(`url(backgroundImg.tablet)),
         ],
       ),
@@ -22,7 +28,10 @@ module Styles = {
         Theme.MediaQuery.desktop,
         [
           width(`percent(100.)),
-          height(`rem(47.)),
+          switch (contentSize) {
+          | `Large => height(`percent(100.))
+          | `Small => height(`rem(47.))
+          },
           backgroundImage(`url(backgroundImg.desktop)),
         ],
       ),
@@ -112,9 +121,10 @@ let make =
       ~header: option(string),
       ~copy,
       ~background: Theme.backgroundImage,
+      ~contentSize=`Small,
       ~children=?,
     ) => {
-  <div className={Styles.heroContainer(background)}>
+  <div className={Styles.heroContainer(background, contentSize)}>
     <div className=Styles.heroContent>
       {ReactExt.fromOpt(title, ~f=s =>
          <h4 className=Styles.headerLabel> {React.string(s)} </h4>

--- a/src/pages/AnnouncementPost.re
+++ b/src/pages/AnnouncementPost.re
@@ -119,6 +119,7 @@ let make = (~post: option(ContentType.Announcement.t)) => {
         title="Announcement"
         header={Some(title)}
         copy={Some(snippet)}
+        contentSize=`Large
         background=Theme.{
           desktop: "/static/img/BlogDetailImage.jpg",
           tablet: "/static/img/BlogDetailImage.jpg",

--- a/src/pages/BlogPost.re
+++ b/src/pages/BlogPost.re
@@ -119,6 +119,7 @@ let make = (~post: option(ContentType.BlogPost.t)) => {
         title="Blog"
         header={Some(title)}
         copy={Js.Undefined.toOption(subtitle)}
+        contentSize=`Large
         background=Theme.{
           desktop: "/static/img/BlogDetailImage.jpg",
           tablet: "/static/img/BlogDetailImage.jpg",


### PR DESCRIPTION
This PR addresses a fix that was made earlier to make the Hero component height universal across all pages. There are some pages that need larger content so this functionality was added as a prop. 