### PR TITLE
Update connecting.mdx

### DIFF
--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -132,6 +132,12 @@ And look at logs:
 journalctl --user -u mina -n 1000 -f
 ```
 
+In some cases in order to view logs you need to run the following command instead:
+
+```
+journalctl --user-unit mina -n 1000 -f
+```
+
 That command will show you the last 1000 lines and follow from there.
 
 ### Docker


### PR DESCRIPTION
I had issues accessing logs:

```
root@Ubuntu-1804-bionic-64-nextcloud ~ # lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.5 LTS
Release:        18.04
Codename:       bionic

root@Ubuntu-1804-bionic-64-nextcloud ~ # journalctl --user -u mina -n 1000 -f
No journal files were found.
```

But after reading man pages on journalctrl I found the solution:

```
root@Ubuntu-1804-bionic-64-nextcloud ~ # journalctl --user-unit mina -n 10
-- Logs begin at Sun 2020-12-20 06:31:01 PST, end at Sun 2020-12-20 23:56:52 PST. --
Dec 20 23:55:43 Ubuntu-1804-bionic-64-nextcloud coda[13405]:         peer: {
Dec 20 23:55:43 Ubuntu-1804-bionic-64-nextcloud coda[13405]:   "host": "35.240.161.228",
Dec 20 23:55:43 Ubuntu-1804-bionic-64-nextcloud coda[13405]:   "peer_id": "12D3KooWH1zioJGn2r1CG48biyXXqqKV5LbLuD34fzdABoLosnMA",
Dec 20 23:55:43 Ubuntu-1804-bionic-64-nextcloud coda[13405]:   "libp2p_port": 53310
Dec 20 23:55:43 Ubuntu-1804-bionic-64-nextcloud coda[13405]: }
```