### PR TITLE
Ignoring package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn-error.log
 .DS_STORE
 *.log
 .merlin*
+package-lock.json


### PR DESCRIPTION
There is a yarn.lock file and this PR prevents accidental inclusion of package-lock.json is a user chooses npm.

The alternative would be to include both but they would need to be kept in sync.