### PR TITLE
Updating discord channel names

### DIFF
--- a/pages/docs/contributing.mdx
+++ b/pages/docs/contributing.mdx
@@ -13,7 +13,7 @@ For any general questions on how to get involved, feel free to reach out to the 
 
 The Mina public testnet beta is live. **Technical skill is not required**, and we encourage anyone with an interest in cryptocurrencies and blockchains to get involved.
 
-Specifically, we need help in the form of reporting bugs, validating economic assumptions, testing out node infrastructure, and general participation in consensus and compressing the blockchain. Please join the [Discord server](https://bit.ly/MinaDiscord) and checkout the #testnet-general and #testnet-beta channel to get involved. You can also [sign up for the Genesis program here](/genesis) and we'll keep you posted with updates!
+Specifically, we need help in the form of reporting bugs, validating economic assumptions, testing out node infrastructure, and general participation in consensus and compressing the blockchain. Please join the [Discord server](https://bit.ly/MinaDiscord) and checkout the #testnet-general and #mentor-nodes channel to get involved. You can also [sign up for the Genesis program here](/genesis) and we'll keep you posted with updates!
 
 Head over to the [testnet landing page](/testnet.html) to see how to participate in weekly challenges and get on the testnet leaderboard.
 
@@ -31,4 +31,4 @@ Currently, the projects are mostly programming focused, but more will be added i
 
 If you notice any [Code of Conduct](https://github.com/MinaProtocol/mina/blob/develop/CODE_OF_CONDUCT.md) violations, please follow the Reporting Guidelines in that document to file a report and alert the community to any bad behavior.
 
-If you encounter any critical bugs or vulnerabilities in the protocol, please report them to security@minaprotocol.com. For minor bugs and issues, please create a issue on Github.
+If you encounter any critical bugs or vulnerabilities in the protocol, please report them to security@minaprotocol.com. For minor bugs and issues, please create an issue on Github.


### PR DESCRIPTION
Trivial typo change and updating the Discord channel name as #testnet-beta was archived.