### PR TITLE
Adding block producer document to protocol architecture

### DIFF
--- a/pages/docs/architecture/block-producers.mdx
+++ b/pages/docs/architecture/block-producers.mdx
@@ -1,0 +1,50 @@
+import Page from "@reason/pages/Docs";
+export default Page({ title: "Block Producers" });
+
+# Block Producers
+
+The role of a block producer in Mina is to achieve [consensus](/docs/architecture/consensus) and provide security to the blockchain. The block producer is responsible for creating new blocks, which include recent transactions broadcast on the network and a blockchain proof that proves the current state of the chain is valid.
+
+In Mina, anyone may become a block producer. There is an unbounded number of participants with the chance of producing a block proportional to the funds staked. Funds are not locked and are not subject to slashing.
+
+In return for staking funds and generating the required blockchain proofs, blocks produced and included in the canonical chain are rewarded in the form of a coinbase and transaction fees, less any fees paid to purchase required [transaction snark work](/docs/architecture/snark-workers).
+
+To produce a block successfully, a block producer must have the current state of the blockchain. Additionally, they must have enough available compute to produce a blockchain SNARK within the slot time and be connected to peers to broadcast the generated block within an acceptable delay as defined by the network consensus parameters.
+
+### Selecting a block producer
+
+The opportunity to produce a block for a slot is determined by a [verifiable random function](https://en.wikipedia.org/wiki/Verifiable_random_function) (VRF). This function can be thought of as a lottery. Each block producer independently runs this VRF for each slot, and if they get an output greater than a threshold proportional to the producer's stake, they have the chance to produce a block at the designated slot.
+
+This process is secret, in that only the private key holder can determine the VRF output, and hence only they know when they are to produce a block. This aids security as it is impossible for an adversary to target a known block producer at a certain slot, e.g., by a denial of service or targeted attack. As a result, it also means that multiple producers can be selected for the same slot. If multiple producers produce a valid block for the same slot, this will produce a short-range fork where the consensus rules will select the longest chain.
+
+The stake distribution is determined from the snarked ledger at the last block of `current epoch-2`, so there is a delay for any recently acquired or [delegated stake](#stake-delegation). For example, if the current epoch is 10, the staking distribution is determined from the snarked ledger of the last block of the 8th epoch.
+
+<Alert>
+
+View the output of the VRF in the logs by looking for `Checking VRF evaluations`.
+
+</Alert>
+
+### Generating a block
+
+When a block producer is selected to produce a block for a slot, they perform the following actions:
+
+* Choose the current best tip from their transition frontier (local store of blocks) on which to build the new block.
+* Select transactions and any snark work required from the transaction and snark pools. A block producer must purchase snark work at least in equal quantity to the transactions they add to a block. In addition to any user transactions, they also add a coinbase transaction as a reward for producing the block and any fee transfers to pay the snark workers.
+* Generate the proposed next state of the blockchain. This comprises creating a diff of the staged ledger that includes the account ledger and scan state (a queue of transactions yet to have proofs). This diff is applied to the existing staged ledger to produce the new state.
+* Creates a blockchain proof to prove that the new state is valid. This SNARK additionally validates the prior protocol state proof.
+* Creates a delta transition chain proof that proves the validity of the block if it is received within an acceptable network delay as defined by the network consensus parameters.
+* Applies this newly generated state locally, adding it into the existing transition frontier.
+* Broadcasts the block (referred to as an external transition) to its peers.
+
+### Stake delegation
+
+An account may increase the probability of being selected to produce a block by delegating tokens to another account. When staking from the delegatee account, the combined funds are used in evaluating the VRF threshold, increasing the likelihood of being selected to produce a block for a slot.
+
+Delegated funds are not spendable and may be undelegated at any time by re-delegating the stake back to the original account.
+
+## Supercharged coinbase
+
+To further incentivize staking, if the account that wins the slot is one that does not have any [time-locked tokens](/docs/architecture/timelock), the block producer will receive double the coinbase rewards.
+
+The supercharged coinbase applies to all accounts, either delegating or staking. The supercharged reward is determined using the account that won the slot. For example, if a non-time-locked account delegates to a time-locked account, if the non-time-locked account wins the slot, the coinbase is supercharged. If the time-locked account wins, the coinbase is not supercharged.

--- a/src/components/DocsNavs.re
+++ b/src/components/DocsNavs.re
@@ -33,6 +33,7 @@ module SideNav = {
         <Section title="Protocol Architecture" slug={f("architecture")}>
           <Item title="Mina Overview" slug="" />
           <Item title="Lifecycle of a Payment" slug="lifecycle-payment" />
+          <Item title="Block Producers" slug="block-producers" />
           <Item title="Consensus" slug="consensus" />
           <Item title="Proof of Stake" slug="proof-of-stake" />
           <Item title="Snark Workers" slug="snark-workers" />
@@ -97,6 +98,7 @@ module Dropdown = {
 
           | "architecture" => "Mina Overview"
           | "architecture/lifecycle-payment" => "Lifecycle of a Payment"
+          | "architecture/block-producers" => "Block Producers"
           | "architecture/consensus" => "Consensus"
           | "architecture/proof-of-stake" => "Proof of Stake"
           | "architecture/snark-workers" => "Snark Workers"
@@ -138,6 +140,7 @@ module Dropdown = {
         <Section title="Protocol Architecture" slug={f("architecture")}>
           <Item title="Mina Overview" slug="" />
           <Item title="Lifecycle of a Payment" slug="lifecycle-payment" />
+          <Item title="Block Producers" slug="block-producers" />
           <Item title="Consensus" slug="consensus" />
           <Item title="Proof of Stake" slug="proof-of-stake" />
           <Item title="Snark Workers" slug="snark-workers" />


### PR DESCRIPTION
Adding documentation for the role of a block producer to the existing protocol architecture section.