### PR TITLE
Docs: Added seperate docs pages for mina-gen-keypair and ledger tool

### DIFF
--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -4,7 +4,7 @@ export default Page({ title: "Generate a Keypair" });
 # Generating a Keypair
 
 
-In order to create a keypair for Mainnet or to fully participate in a Mina test network, the first step is to generate a Keypair, which consists of a Public Key and a Private Key. Currently there are several ways to generate a Keypair, firstly being the mina-generate-keypair tool and secondly the ledger-app-mina tool.
+In order to create a keypair for Mainnet or to fully participate in a Mina test network, the first step is to generate a Keypair, which consists of a Public Key and a Private Key. Currently there are two supported tools for generating keypairs mina-generate-keypair and ledger-app-mina.
 
 <br />
 
@@ -14,7 +14,7 @@ We've created a simple command-line utility called `mina-generate-keypair`. Plea
 
 ## ledger-app-mina 
 
-A Mina app for the [Nano S/X hardware wallet](https://www.ledger.com/) supports creating a Keypair as well. It is currently undergoing a security audit, otherwise development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
+You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wallet to securely store your Mina private keys. It is currently undergoing a security audit, otherwise development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
 
 <br />
 

--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -16,6 +16,8 @@ We've created a simple command-line utility called `mina-generate-keypair`. Plea
 
 You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wallet to securely store your Mina private keys. We are in the process of an independent security audit which currently has found no vulnerabilities, and development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
 
+Note: We are still iterating a bit on this process, so check back here every few days for updates!
+
 <br />
 
 <Alert kind="warning">

--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -4,34 +4,28 @@ export default Page({ title: "Generate a Keypair" });
 # Generating a Keypair
 
 
-In order to fully participate in the Mina network, the first step is to generate a Keypair, which consists of a Public Key and a Private Key. Currently there are several ways to generate a Keypair, firstly being the mina-generate-keypair tool and secondly the ledger-app-mina tool.
-
-<Alert>
-
-If you have previously created a keypair after Testnet 3.2b (public key should begin with `B62...`), you can re-use the previous keypair and skip ahead to [connect to the network](/docs/connecting).
-
-</Alert>
+In order to create a keypair for Mainnet or to fully participate in a Mina test network, the first step is to generate a Keypair, which consists of a Public Key and a Private Key. Currently there are several ways to generate a Keypair, firstly being the mina-generate-keypair tool and secondly the ledger-app-mina tool.
 
 <br />
 
 ## mina-generate-keypair
 
-To simplify the process of creating a keypair, we've created a simple command-line utility called `mina-generate-keypair`. Please see our [mina-generate-keypair documentation](/docs/keypair/mina-generate-keypair) to get started with installing and using the tool to generate your Keypair. We recommend this method for now as the `ledger-app-mina` tool is still under development.
+We've created a simple command-line utility called `mina-generate-keypair`. Please see our [mina-generate-keypair documentation](/docs/keypair/mina-generate-keypair) to get started with installing and using the tool to generate your Keypair.
 
 ## ledger-app-mina 
 
-A Mina app for the [Nano S/X hardware wallet](https://www.ledger.com/) being developed currently and supports creating a Keypair as well. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
+A Mina app for the [Nano S/X hardware wallet](https://www.ledger.com/) supports creating a Keypair as well. It is currently undergoing a security audit, otherwise development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
 
 <br />
 
 <Alert kind="warning">
 
-Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead.
+Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead. Mina will never ask you for your private keys.
 
 </Alert>
 
 <br />
 
-## Connecting to the network 
+## Next steps
 
-Now that we have created our keypair, we can finally [connect to the network](/docs/connecting)!
+Now that we have created our keypair, we can finally [connect to the network](/docs/connecting) or share your public key.

--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -14,7 +14,7 @@ We've created a simple command-line utility called `mina-generate-keypair`. Plea
 
 ## ledger-app-mina 
 
-You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wallet to securely store your Mina private keys. We are currently wrapping up a security audit which has found no vulnerabilities, otherwise development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
+You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wallet to securely store your Mina private keys. We are in the process of an independent security audit which currently has found no vulnerabilities, and development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
 
 <br />
 

--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -1,0 +1,37 @@
+import Page from "@reason/pages/Docs";
+export default Page({ title: "Generate a Keypair" });
+
+# Generating a Keypair
+
+
+In order to fully participate in the Mina network, the first step is to generate a Keypair, which consists of a Public Key and a Private Key. Currently there are several ways to generate a Keypair, firstly being the mina-generate-keypair tool and secondly the ledger-app-mina tool.
+
+<Alert>
+
+If you have previously created a keypair after Testnet 3.2b (public key should begin with `B62...`), you can re-use the previous keypair and skip ahead to [connect to the network](/docs/connecting).
+
+</Alert>
+
+<br />
+
+## mina-generate-keypair
+
+To simplify the process of creating a keypair, we've created a simple command-line utility called `mina-generate-keypair`. Please see our [mina-generate-keypair documentation](/docs/keypair/mina-generate-keypair) to get started with installing and using the tool to generate your Keypair. We recommend this method for now as the `ledger-app-mina` tool is still under development.
+
+## ledger-app-mina 
+
+A Mina app for the [Nano S/X hardware wallet](https://www.ledger.com/) being developed currently and supports creating a Keypair as well. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
+
+<br />
+
+<Alert kind="warning">
+
+Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead.
+
+</Alert>
+
+<br />
+
+## Connecting to the network 
+
+Now that we have created our keypair, we can finally [connect to the network](/docs/connecting)!

--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -14,7 +14,7 @@ We've created a simple command-line utility called `mina-generate-keypair`. Plea
 
 ## ledger-app-mina 
 
-You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wallet to securely store your Mina private keys. It is currently undergoing a security audit, otherwise development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
+You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wallet to securely store your Mina private keys. We are currently wrapping up a security audit which has found no vulnerabilities, otherwise development is nearly completed. Please see our [ledger-app-mina documentation](/docs/keypair/ledger-app-mina) to get started with this tool.
 
 <br />
 

--- a/pages/docs/keypair/ledger-app-mina.mdx
+++ b/pages/docs/keypair/ledger-app-mina.mdx
@@ -100,7 +100,9 @@ Your Ledger device will ask if you want to install the Mina app.
 
 Click left until you see
 
+```
 < ✓ Perform installation >
+```
 
 Select this option and enter your Ledger PIN code.
 
@@ -184,7 +186,9 @@ Your Ledger device will ask if you want to install the Mina app.
 
 Click left until you see
 
+```
 < ✓ Perform installation >
+```
 
 Select this option and enter your Ledger PIN code.
 
@@ -244,6 +248,3 @@ Received address: B62qk2o9hqZRjAhG7skhWVXGtCfMdtqBvCTjVfYeh4mqLvrLmBQUmAY
 
 (Note: your address 42 will be different than this one.)
 
-## Connecting to the network
-
-Now that we have created our keypair, we can finally [connect to the network](/docs/connecting)!

--- a/pages/docs/keypair/ledger-app-mina.mdx
+++ b/pages/docs/keypair/ledger-app-mina.mdx
@@ -1,0 +1,16 @@
+import Page from "@reason/pages/Docs";
+export default Page({ title: "Ledger App Mina" });
+
+
+# ledger-app-mina
+
+A Mina app for the [Nano S/X hardware wallet](https://www.ledger.com/) being developed currently and supports creating a Keypair as well. Follow the instructions below to build and install the tool onto your system.
+
+## Installation
+
+As this tool is under development, please visit the [Github readme](https://github.com/jspada/ledger-app-mina/blob/master/README.md) to keep up to date on how to use this tool. 
+
+
+## Connecting to the network 
+
+Now that we have created our keypair, we can finally [connect to the network](/docs/connecting)!

--- a/pages/docs/keypair/ledger-app-mina.mdx
+++ b/pages/docs/keypair/ledger-app-mina.mdx
@@ -19,7 +19,7 @@ If you have a Nano S, you can still sideload it onto your Ledger device by follo
 <Alert kind="warning">
 This is beta software and is still in development.  Use at your own risk.  Make sure your Ledger's BIP39 secret
 mnemonic phrase is backed up or use a separate Ledger device for testing this app.
-<Alert>
+</Alert>
 
 ## Installing on Ubuntu
 

--- a/pages/docs/keypair/ledger-app-mina.mdx
+++ b/pages/docs/keypair/ledger-app-mina.mdx
@@ -11,12 +11,14 @@ The operations supported are
 - Signing payment transactions
 - Signing delegation transactions
 
-This functionality is currently under development and there is a Pre-release for testing.
+We are currently wrapping up a security audit which has found no vulnerabilities, otherwise development is nearly completed.
 
 The app is not yet available for install through the Ledger Live user interface, but if you have a Nano S, you can sideload it onto your Ledger device by following the instructions below.
 
 <Alert kind="warning">
-This is beta software and is still in development.  Use at your own risk.  Make sure you have a backup of your Ledger's BIP39 secret
+We are currently wrapping up a security audit which has found no vulnerabilities, otherwise development is nearly completed.
+
+Use at your own risk.  Make sure you have a backup of your Ledger's BIP39 secret
 mnemonic phrase or use a separate Ledger device for testing this app.
 </Alert>
 

--- a/pages/docs/keypair/ledger-app-mina.mdx
+++ b/pages/docs/keypair/ledger-app-mina.mdx
@@ -11,7 +11,7 @@ The operations supported are
 - Signing payment transactions
 - Signing delegation transactions
 
-We are currently wrapping up a security audit which has found no vulnerabilities, otherwise development is nearly completed.
+We are in the process of an independent a security audit which has currently found no vulnerabilities, otherwise development is nearly completed.
 
 The app is not yet available for install through the Ledger Live user interface, but if you have a Nano S, you can sideload it onto your Ledger device by following the instructions below.
 

--- a/pages/docs/keypair/mina-generate-keypair.mdx
+++ b/pages/docs/keypair/mina-generate-keypair.mdx
@@ -59,7 +59,7 @@ This will create two files on your system, `~/keys/my-wallet` which contains the
 
 <Alert kind="warning">
 
-Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead.
+Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead. Mina will never ask you for your private keys.
 
 </Alert>
 
@@ -71,7 +71,3 @@ Finally, ensure the permissions are set properly for the private key file, this 
 chmod 600 ~/keys/my-wallet
 ```
 
-
-## Connecting to the network 
-
-Now that we have created our keypair, we can finally [connect to the network](/docs/connecting)!

--- a/pages/docs/keypair/mina-generate-keypair.mdx
+++ b/pages/docs/keypair/mina-generate-keypair.mdx
@@ -1,19 +1,15 @@
 import Page from "@reason/pages/Docs";
-export default Page({ title: "Generate a Keypair" });
+export default Page({ title: "Mina Generate Keypair" });
 
-# Generating a Keypair
 
-In order to fully participate in the Mina network, the first step is to generate a Keypair, which consists of a Public Key and a Private Key. 
+# mina-generate-keypair
 
-<Alert>
-
-For Testworld, we are sending out pre-generated keypairs to every participant and you do not need to generate a keypair. Follow the instructions to setup your keypair [here](/docs/connecting#setup-keypair).
-
-</Alert>
+To simplify the process of creating a keypair, we've created a simple command-line utility called `mina-generate-keypair`. The `mina-generate-keypair` tool has easy to use functionality to create your own Keypair to start participating in the Mina network. Please see below to see how to install and use on your local system.
 
 ## Installation
 
-To simplify the process of creating a keypair, we've created a simple command-line utility called `mina-generate-keypair`. Follow the instructions below to install the tool onto your system.
+We support several different operating systems for the `mina-generate-keypair` tool. Follow the instructions below to install the tool onto your system.
+
 
 ### macOS
 
@@ -51,7 +47,7 @@ Next, ensure the permissions are set properly this folder, this prevents unwante
 chmod 700 ~/keys
 ```
 
-Now we can generate our keys using the `mina-generate-keypair` command. You will be prompted to provide a password for the new keypair. <em>Do NOT forget this password.</em> 
+Now we can generate our keys using the `mina-generate-keypair` command. You will be prompted to provide a password for the new keypair. <em>Do NOT forget this password.</em>
 
 ```
 mina-generate-keypair -privkey-path ~/keys/my-wallet
@@ -59,22 +55,23 @@ mina-generate-keypair -privkey-path ~/keys/my-wallet
 
 This will create two files on your system, `~/keys/my-wallet` which contains the encrypted private key and `~/keys/my-wallet.pub` which contains the public key in plain text. Please store the private key file and password you used in a secure place, such as a password manager.
 
+<br />
+
+<Alert kind="warning">
+
+Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead.
+
+</Alert>
+
+<br />
+
 Finally, ensure the permissions are set properly for the private key file, this prevents unwanted processes from accessing it.
 
 ```
 chmod 600 ~/keys/my-wallet
 ```
 
-## Submit your Public Key
 
-In the days leading up to a Testnet, we will begin collecting public keys from the community for Staking Signups. To see your public key use the following command:
-
-```
-cat ~/keys/my-wallet.pub
-```
-
-Copy the output of the command and submit it to the [Staking Signup](https://bit.ly/TestnetSignUp) form along with your Discord username.
-
-## Next
+## Connecting to the network 
 
 Now that we have created our keypair, we can finally [connect to the network](/docs/connecting)!

--- a/src/components/DocsNavs.re
+++ b/src/components/DocsNavs.re
@@ -22,7 +22,6 @@ module SideNav = {
           <Item title="mina-generate-keypair" slug="mina-generate-keypair" />
           <Item title="ledger-app-mina" slug="ledger-app-mina" />
         </Section>
-        //<Item title="Generate a Keypair" slug={f("keypair")} />
         <Item title="Connect to the Network" slug={f("connecting")} />
         <Item title="Tips for Node Operators" slug={f("node-operator")} />
         <Item title="Hard Fork" slug={f("hard-fork")} />
@@ -103,6 +102,10 @@ module Dropdown = {
           | "developers/graphql-api" => "GraphQL API"
           | "developers/logging" => "Logging"
 
+          | "keypair" => "Keypair Overview"
+          | "keypair/mina-generate-keypair" => "mina-generate-keypair"
+          | "keypair/ledger-app-mina" => "ledger-app-mina"
+
           | "architecture" => "Mina Overview"
           | "architecture/lifecycle-payment" => "Lifecycle of a Payment"
           | "architecture/block-producers" => "Block Producers"
@@ -131,7 +134,11 @@ module Dropdown = {
       <DropdownNav currentSlug defaultValue={getCurrentValue(currentSlug)}>
         <Item title="Overview" slug="/docs" />
         <Item title="Getting Started" slug={f("getting-started")} />
-        <Item title="Generate a Keypair" slug={f("keypair")} />
+        <Section title="Generate a Keypair" slug={f("keypair")}>
+          <Item title="Keypair Overview" slug="" />
+          <Item title="mina-generate-keypair" slug="mina-generate-keypair" />
+          <Item title="ledger-app-mina" slug="ledger-app-mina" />
+        </Section>
         <Item title="Connect to the Network" slug={f("connecting")} />
         <Item title="Tips for Node Operators" slug={f("node-operator")} />
         <Item title="Hard Fork" slug={f("hard-fork")} />

--- a/src/components/DocsNavs.re
+++ b/src/components/DocsNavs.re
@@ -17,7 +17,12 @@ module SideNav = {
       <SideNav currentSlug>
         <Item title="Overview" slug="/docs" />
         <Item title="Getting Started" slug={f("getting-started")} />
-        <Item title="Generate a Keypair" slug={f("keypair")} />
+        <Section title="Generate a Keypair" slug={f("keypair")}>
+          <Item title="Keypair Overview" slug="" />
+          <Item title="mina-generate-keypair" slug="mina-generate-keypair" />
+          <Item title="ledger-app-mina" slug="ledger-app-mina" />
+        </Section>
+        //<Item title="Generate a Keypair" slug={f("keypair")} />
         <Item title="Connect to the Network" slug={f("connecting")} />
         <Item title="Tips for Node Operators" slug={f("node-operator")} />
         <Item title="Hard Fork" slug={f("hard-fork")} />


### PR DESCRIPTION
This PR adds a top-level docs page for generating a keypair and then adds separate pages for the `mina-generate-keypair` and `ledger-mina-`app tool.