### PR TITLE
Corrected: Debian 18.04 --> Ubuntu 18.04

### DIFF
--- a/pages/docs/keypair/mina-generate-keypair.mdx
+++ b/pages/docs/keypair/mina-generate-keypair.mdx
@@ -21,7 +21,7 @@ brew install minaprotocol/mina/mina-generate-keypair
 
 You can now run `mina-generate-keypair -version` to check that the installation completed successfully.
 
-### Debian 18.04 / Debian 9
+### Ubuntu 18.04 / Debian 9
 
 After [adding the Mina repo](/docs/getting-started#ubuntu-1804--debian-9) you can simply run the following command.
 


### PR DESCRIPTION
Changed "Debian 18.04" to "Ubuntu 18.04" - typo