### PR TITLE
Adding docs for client SDK

### DIFF
--- a/pages/docs/developers/client-sdk.mdx
+++ b/pages/docs/developers/client-sdk.mdx
@@ -1,0 +1,101 @@
+import Page from "@reason/pages/Docs";
+export default Page({ title: "Client SDK" });
+
+# Client SDK
+
+The [Mina Client Javascript SDK](https://www.npmjs.com/package/@o1labs/client-sdk) allows generating keypairs, signing and verifying messages, and signing transactions that can be broadcast to the network. 
+
+The project contains Typescript and ReasonML typings but can be used from plain NodeJS as well. The following methods are available:
+
+* `genKeys` - generates a public/private keypair.
+* `derivePublicKey` - derives the public key of the corresponding private key.
+* `signMessage` - signs an arbitrary message.
+* `verifyMessage` - verifies that a signature matches a message.
+* `signPayment` - signs a payment using a private key.
+* `signStakeDelegation` - signs a stake delegation using a private key.
+
+<Alert>
+
+The client SDK enables the ability to generate and sign transactions on an air-gapped device that never exposes a private key to the internet.
+
+</Alert>
+
+## Install
+
+```
+yarn add @o1labs/client-sdk
+# or with npm:
+npm install --save @o1labs/client-sdk
+```
+
+## Usage
+
+### Typescript
+
+```
+import * as CodaSDK from "@o1labs/client-sdk";
+
+let keys = CodaSDK.genKeys();
+let signed = CodaSDK.signMessage("hello", keys);
+if (CodaSDK.verifyMessage(signed)) {
+    console.log("Message was verified successfully")
+};
+
+let signedPayment = CodaSDK.signPayment({
+    to: keys.publicKey,
+    from: keys.publicKey,
+    amount: 1,
+    fee: 1,
+    nonce: 0
+  }, keys);
+```
+
+### NodeJS
+
+```
+const CodaSDK = require("@o1labs/client-sdk");
+
+let keys = CodaSDK.genKeys();
+let signed = CodaSDK.signMessage("hello", keys);
+if (CodaSDK.verifyMessage(signed)) {
+    console.log("Message was verified successfully")
+};
+
+let signedPayment = CodaSDK.signPayment({
+    to: keys.publicKey,
+    from: keys.publicKey,
+    amount: 1,
+    fee: 1,
+    nonce: 0
+  }, keys);
+```
+
+### ReasonML
+
+* Install gentype: `yarn add -D gentype`
+* Install bs-platform: `yarn add -D bs-platform`
+* Build dependencies: `yarn bsb -make-world`
+
+```
+module CodaSDK = O1labsClientSdk.CodaSDK;
+
+let keys = CodaSDK.genKeys();
+let signed = CodaSDK.signMessage(. "hello", keys);
+if (CodaSDK.verifyMessage(. signed)) {
+  Js.log("Message was verified successfully");
+};
+
+let signedPayment = CodaSDK.signPayment({
+    to_: keys.publicKey,
+    from: keys.publicKey,
+    amount: "1",
+    fee: "1",
+    nonce: "0"
+  }, keys);
+```
+
+<Alert>
+
+When generating transactions, you will need to specify the account nonce. This is available for an account via the CLI using `coda advanced get-nonce -address <PUBLIC_KEY>` or using [GraphQL](/docs/developers/graphql-api).
+
+</Alert>

--- a/src/components/DocsNavs.re
+++ b/src/components/DocsNavs.re
@@ -37,6 +37,7 @@ module SideNav = {
           <Item title="Style Guide" slug="style-guide" />
           <Item title="Sandbox Node" slug="sandbox-node" />
           <Item title="GraphQL API" slug="graphql-api" />
+          <Item title="Client SDK" slug="client-sdk" />
           <Item title="Logging" slug="logging" />
         </Section>
         <Section title="Protocol Architecture" slug={f("architecture")}>
@@ -105,6 +106,7 @@ module Dropdown = {
           | "developers/style-guide" => "Style Guide"
           | "developers/sandbox-node" => "Sandbox Node"
           | "developers/graphql-api" => "GraphQL API"
+          | "developers/client-sdk" => "Client SDK"
           | "developers/logging" => "Logging"
 
           | "keypair" => "Keypair Overview"
@@ -156,6 +158,7 @@ module Dropdown = {
           <Item title="Style Guide" slug="style-guide" />
           <Item title="Sandbox Node" slug="sandbox-node" />
           <Item title="GraphQL API" slug="graphql-api" />
+          <Item title="Client SDK" slug="client-sdk" />
           <Item title="Logging" slug="logging" />
         </Section>
         <Section title="Protocol Architecture" slug={f("architecture")}>


### PR DESCRIPTION
Adding the client SDK docs to the main website so they can be easily found.

I've also added this additional derivePublicKey method that hasn't been merged yet https://github.com/MinaProtocol/mina/pull/7512