### PR TITLE
Output for the version of mina-generate-keypair

### DIFF
--- a/pages/docs/keypair/mina-generate-keypair.mdx
+++ b/pages/docs/keypair/mina-generate-keypair.mdx
@@ -39,7 +39,7 @@ After [adding the Mina repo](/docs/getting-started#ubuntu-1804--debian-9) you ca
 sudo apt-get install mina-generate-keypair=0.2.6-5dfcc52 --allow-downgrades
 ```
 
-You can run `mina-generate-keypair -version` to check that the installation completed successfully.
+You can run `mina-generate-keypair -version` to check that the installation completed successfully. `NO_VERSION_UTIL` is the correct output.
 
 ## Usage
 


### PR DESCRIPTION
There was a confusion about the output of `mina-generate-keypair -version` that was correctly `NO_VERSION_UTIL`. Just added a comment to avoid confusion.
see here https://discord.com/channels/484437221055922177/799597981762453535/801156819078479902