### PR TITLE
0.2.9 Update all packages and versions to 0.2.9

### DIFF
--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -24,10 +24,10 @@ First remove any previously installed version of the daemon to prevent any error
 sudo apt-get remove -y mina-testnet-postake-medium-curves
 echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
-sudo apt-get install -y curl unzip mina-testnet-postake-medium-curves=0.2.6-5c08d6d --allow-downgrades
+sudo apt-get install -y curl unzip mina-testnet-postake-medium-curves=0.2.7-fbe3495
 ```
 
-Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]5c08d6d51111d31269e77f3c62a544b3262ee4c8 on branch HEAD`.
+Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0 on branch HEAD`.
 
 ## Setup Keypair
 
@@ -176,7 +176,7 @@ docker run --name mina -d \
 --mount "type=bind,source=`pwd`/.coda-config,dst=/root/.coda-config" \
 --mount "type=bind,source=`pwd`/peers.txt,dst=/root/peers.txt,readonly" \
 -e CODA_PRIVKEY_PASS="YOUR PASSWORD HERE" \
-gcr.io/o1labs-192920/coda-daemon-baked:0.2.6-5c08d6d-5c08d6d-testworld-2258826 \
+minaprotocol/mina-daemon-baked:0.2.7-fbe3495-testworld-0bc5977e \
 daemon \
 -peer-list-file /root/peers.txt \
 -block-producer-key /keys/my-wallet \

--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -176,7 +176,7 @@ docker run --name mina -d \
 --mount "type=bind,source=`pwd`/.coda-config,dst=/root/.coda-config" \
 --mount "type=bind,source=`pwd`/peers.txt,dst=/root/peers.txt,readonly" \
 -e CODA_PRIVKEY_PASS="YOUR PASSWORD HERE" \
-minaprotocol/mina-daemon-baked:0.2.7-fbe3495-testworld-0bc5977e \
+minaprotocol/mina-daemon-baked:0.2.7-fbe3495-testworld-0bc5977 \
 daemon \
 -peer-list-file /root/peers.txt \
 -block-producer-key /keys/my-wallet \

--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -24,10 +24,10 @@ First remove any previously installed version of the daemon to prevent any error
 sudo apt-get remove -y mina-testnet-postake-medium-curves
 echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
-sudo apt-get install -y curl unzip mina-testnet-postake-medium-curves=0.2.7-fbe3495
+sudo apt-get install -y curl unzip mina-testnet-postake-medium-curves=0.2.9-a940247
 ```
 
-Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0 on branch HEAD`.
+Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]a9402473584c36b347d52df4f4000b7286385987 on branch HEAD`.
 
 ## Setup Keypair
 
@@ -176,7 +176,7 @@ docker run --name mina -d \
 --mount "type=bind,source=`pwd`/.coda-config,dst=/root/.coda-config" \
 --mount "type=bind,source=`pwd`/peers.txt,dst=/root/peers.txt,readonly" \
 -e CODA_PRIVKEY_PASS="YOUR PASSWORD HERE" \
-minaprotocol/mina-daemon-baked:0.2.7-fbe3495-testworld-0bc5977 \
+minaprotocol/mina-daemon-baked:0.2.9-a940247-testworld-a940247 \
 daemon \
 -peer-list-file /root/peers.txt \
 -block-producer-key /keys/my-wallet \

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -61,10 +61,10 @@ Add the Mina Debian repo and install:
 ```
 echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
-sudo apt-get install -y curl mina-testnet-postake-medium-curves=0.2.7-fbe3495
+sudo apt-get install -y curl mina-testnet-postake-medium-curves=0.2.9-a940247
 ```
 
-Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0  on branch HEAD`.
+Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]a9402473584c36b347d52df4f4000b7286385987 on branch HEAD`.
 
 ### Windows
 

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -61,10 +61,10 @@ Add the Mina Debian repo and install:
 ```
 echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
-sudo apt-get install -y curl mina-testnet-postake-medium-curves=0.2.6-5c08d6d --allow-downgrades
+sudo apt-get install -y curl mina-testnet-postake-medium-curves=0.2.7-fbe3495
 ```
 
-Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]5c08d6d51111d31269e77f3c62a544b3262ee4c8  on branch HEAD`.
+Check that daemon installed correctly by running `coda version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0  on branch HEAD`.
 
 ### Windows
 

--- a/pages/docs/keypair/mina-generate-keypair.mdx
+++ b/pages/docs/keypair/mina-generate-keypair.mdx
@@ -19,17 +19,17 @@ Install using [Homebrew](https://brew.sh/)
 brew install minaprotocol/mina/mina-generate-keypair
 ```
 
-You can now run `mina-generate-keypair -version` to check that the installation completed successfully.
+Check that keygen tool installed correctly by running `mina-generate-keypair -version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0 on branch HEAD`.
 
 ### Ubuntu 18.04 / Debian 9
 
 After [adding the Mina repo](/docs/getting-started#ubuntu-1804--debian-9) you can simply run the following command.
 
 ```
-sudo apt-get install mina-generate-keypair=0.2.6-5c08d6d --allow-downgrades
+sudo apt-get install mina-generate-keypair=0.2.7-fbe3495
 ```
 
-You can run `mina-generate-keypair -version` to check that the installation completed successfully.
+Check that keygen tool installed correctly by running `mina-generate-keypair -version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0 on branch HEAD`.
 
 ### Windows / Other Platforms
 
@@ -73,7 +73,7 @@ mina-generate-keypair -privkey-path ~/keys/my-wallet
 
 ```
 cd ~
-docker run  --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/generate-keypair:0.2.6-5dfcc52 -privkey-path /keys/my-wallet
+docker run  --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/generate-keypair:0.2.7-fbe3495 -privkey-path /keys/my-wallet
 ```
 
 This will create two files on your system, `~/keys/my-wallet` which contains the encrypted private key and `~/keys/my-wallet.pub` which contains the public key in plain text. Please store the private key file and password you used in a secure place, such as a password manager.

--- a/pages/docs/keypair/mina-generate-keypair.mdx
+++ b/pages/docs/keypair/mina-generate-keypair.mdx
@@ -19,7 +19,7 @@ Install using [Homebrew](https://brew.sh/)
 brew install minaprotocol/mina/mina-generate-keypair
 ```
 
-Check that keygen tool installed correctly by running `mina-generate-keypair -version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0 on branch HEAD`.
+Check that keygen tool installed correctly by running `mina-generate-keypair -version`. The output should read `Commit [DIRTY]a9402473584c36b347d52df4f4000b7286385987 on branch HEAD`.
 
 ### Ubuntu 18.04 / Debian 9
 
@@ -29,7 +29,7 @@ After [adding the Mina repo](/docs/getting-started#ubuntu-1804--debian-9) you ca
 sudo apt-get install mina-generate-keypair=0.2.7-fbe3495
 ```
 
-Check that keygen tool installed correctly by running `mina-generate-keypair -version`. The output should read `Commit [DIRTY]fbe3495da7ffe7378a900dd080918095972e70a0 on branch HEAD`.
+Check that keygen tool installed correctly by running `mina-generate-keypair -version`. The output should read `Commit [DIRTY]a9402473584c36b347d52df4f4000b7286385987 on branch HEAD`.
 
 ### Windows / Other Platforms
 
@@ -73,7 +73,7 @@ mina-generate-keypair -privkey-path ~/keys/my-wallet
 
 ```
 cd ~
-docker run  --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/generate-keypair:0.2.7-fbe3495 -privkey-path /keys/my-wallet
+docker run  --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/generate-keypair:0.2.9-a940247 -privkey-path /keys/my-wallet
 ```
 
 This will create two files on your system, `~/keys/my-wallet` which contains the encrypted private key and `~/keys/my-wallet.pub` which contains the public key in plain text. Please store the private key file and password you used in a secure place, such as a password manager.


### PR DESCRIPTION
also remove --allow-downgrades flag to apt as we shouldn't need it with the new release process

Updates here to the mina-generate-keypair docs assume a brew package update that hasn't happened yet. This docs update is not quite ready for primetime.