### PR TITLE
Docs: Client SDK Key Generation

### DIFF
--- a/pages/docs/keypair/client-sdk.mdx
+++ b/pages/docs/keypair/client-sdk.mdx
@@ -1,0 +1,125 @@
+import Page from "@reason/pages/Docs";
+export default Page({ title: "Mina Client SDK Keypair" });
+
+
+# Client SDK 
+
+This is a NodeJS client SDK that allows you to generate Mina key pairs and sign transactions and strings using Mina's key pairs.
+The project contains Typescript and ReasonML typings but can be used from plain NodeJS as well. 
+
+## Installation
+
+```bash
+yarn add @o1labs/client-sdk
+# or with npm:
+npm install --save @o1labs/client-sdk
+```
+
+## Usage
+
+Creating a key pair is simple with our client SDK. See the snippet below to see how to get create a key pair.
+
+NodeJS:
+```javascript
+const CodaSDK = require("@o1labs/client-sdk");
+
+let keys = CodaSDK.genKeys();
+console.log(`Public key: ${keys.publicKey}`)
+console.log(`Private key: ${keys.privateKey}`)
+```
+
+Please see the [client SDK readme](https://github.com/MinaProtocol/mina/blob/develop/frontend/client_sdk/README.md) for more information.
+
+<br />
+
+<Alert kind="warning">
+
+Never give out your private key and make sure they are stored safely. If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and will lose your account funds. Always give out your public keys instead. Mina will never ask you for your private keys.
+
+</Alert>
+
+<br />
+
+## Import your account generated from the SDK
+
+Please note that there are differences in key pair format between what the Mina client expects and what the client SDK generates. 
+When the client SDK is used to generate a key pair, the key pair output returned are strings that aren't directly importable into our Mina client. 
+For this, we will have to use the `coda advanced wrap-key` tool to format our key pair strings into a format that is directly importable to our client.
+
+Accomplishing this takes only a few short steps.
+
+1. First, make sure you have a folder on your system where you can store the key files. We recommend using the ~/keys folder.
+
+```
+mkdir ~/keys
+```
+
+2. Next, ensure the permissions are set properly this folder, this prevents unwanted processes from accessing these files.
+
+```
+chmod 700 ~/keys
+```
+
+3. Copy the private key output into a file in the ~/keys folder
+
+```
+echo 'YOUR-PRIVATE_KEY' > ~/keys/my-wallet
+```
+4. Ensure the permissions are set properly for the private key file, this prevents unwanted processes from accessing it.
+
+```
+chmod 600 ~/keys/my-wallet
+```
+
+5. Use the `coda advanced wrap-key` tool to format your key pair into an importable format for the Mina client. Please note that using `coda advanced wrap-key` will force you to reset your password on your private key.
+
+```
+mina advanced wrap-key -privkey-path ~/keys/my-wallet
+```
+
+You will be prompted for a new password, as shown below.
+
+```
+Private key:
+Password for new private key file: 
+Again to confirm:
+```
+
+This will generate a new `my-wallet.pub` and `my-wallet` file.
+
+```
+ls ~/keys/
+my-wallet  my-wallet.pub
+```
+
+6. Ensure the permissions are set properly for the newley created private key file.
+
+```
+chmod 600 ~/keys/my-wallet
+```
+
+7. Finally, we can import the account created by the client SDK into the client.
+
+```
+ls ~/keys/
+coda accounts import -privkey-path ~/keys/my-wallet
+```
+
+You will be prompted for the password you entered when the account was created with `coda advanced wrap-key`.
+
+The response from this command will look like this: 
+```
+😄 Imported account!
+Public key: B62qjaA4N9843FKM5FZk1HmeuDiojG42cbCDyZeUDQVjycULte9PFkC
+```
+
+
+## Validate your private key
+
+Now that you've created your key -- you'll want to validate that it works. It's sufficient to verify that you can sign a transaction. You can verify this using the `mina-validate-keypair` tool.
+
+Run the following command:
+
+```
+mina-validate-keypair -privkey-path ~/keys/my-wallet
+```

--- a/pages/docs/keypair/client-sdk.mdx
+++ b/pages/docs/keypair/client-sdk.mdx
@@ -13,7 +13,7 @@ The project contains Typescript and ReasonML typings but can be used from plain 
 <Alert kind="warning">
 
 Please be advised that generating key pairs with this method is unadvised and should only be used by experienced security professionals.
-Please use our [mina-generate-keyair](/docs/keypair/mina-generate-keypair) tool instead for creating key pairs.
+Please use our [mina-generate-keypair](/docs/keypair/mina-generate-keypair) tool instead for creating key pairs.
 
 </Alert>
 
@@ -22,7 +22,7 @@ Please use our [mina-generate-keyair](/docs/keypair/mina-generate-keypair) tool 
 
 The source code for our client SDK is open source and be seen [here](https://github.com/MinaProtocol/mina/tree/develop/frontend/client_sdk).
 
-To get the client SDK installed, you will need NodeJS on your system. Make sure it is available on your machine and then use either yarn or npm to install the client SDK
+To get the client SDK installed, you will need NodeJS on your system. Make sure it is available on your machine and then use either yarn or npm to install the client SDK.
 
 ```bash
 # yarn:

--- a/pages/docs/keypair/client-sdk.mdx
+++ b/pages/docs/keypair/client-sdk.mdx
@@ -7,11 +7,28 @@ export default Page({ title: "Mina Client SDK Keypair" });
 This is a NodeJS client SDK that allows you to generate Mina key pairs and sign transactions and strings using Mina's key pairs.
 The project contains Typescript and ReasonML typings but can be used from plain NodeJS as well. 
 
+
+<br />
+
+<Alert kind="warning">
+
+Please be advised that generating key pairs with this method is unadvised and should only be used by experienced security professionals.
+Please use our [mina-generate-keyair](/docs/keypair/mina-generate-keypair) tool instead for creating key pairs.
+
+</Alert>
+
+
 ## Installation
 
+The source code for our client SDK is open source and be seen [here](https://github.com/MinaProtocol/mina/tree/develop/frontend/client_sdk).
+
+To get the client SDK installed, you will need NodeJS on your system. Make sure it is available on your machine and then use either yarn or npm to install the client SDK
+
 ```bash
+# yarn:
 yarn add @o1labs/client-sdk
-# or with npm:
+
+# npm:
 npm install --save @o1labs/client-sdk
 ```
 
@@ -19,7 +36,7 @@ npm install --save @o1labs/client-sdk
 
 Creating a key pair is simple with our client SDK. See the snippet below to see how to get create a key pair.
 
-NodeJS:
+### NodeJS:
 ```javascript
 const CodaSDK = require("@o1labs/client-sdk");
 
@@ -27,8 +44,9 @@ let keys = CodaSDK.genKeys();
 console.log(`Public key: ${keys.publicKey}`)
 console.log(`Private key: ${keys.privateKey}`)
 ```
+This will print your private key so make sure you are in a secure environment when using this method.
 
-Please see the [client SDK readme](https://github.com/MinaProtocol/mina/blob/develop/frontend/client_sdk/README.md) for more information.
+Please see the [client SDK readme](https://github.com/MinaProtocol/mina/blob/develop/frontend/client_sdk/README.md) for more information on how to use our SDK.
 
 <br />
 
@@ -54,13 +72,13 @@ Accomplishing this takes only a few short steps.
 mkdir ~/keys
 ```
 
-2. Next, ensure the permissions are set properly this folder, this prevents unwanted processes from accessing these files.
+2. Next, ensure the permissions are set properly in this folder, this prevents unwanted processes from accessing these files.
 
 ```
 chmod 700 ~/keys
 ```
 
-3. Copy the private key output into a file in the ~/keys folder
+3. Copy the private key output into a file in the ~/keys folder.
 
 ```
 echo 'YOUR-PRIVATE_KEY' > ~/keys/my-wallet
@@ -74,7 +92,7 @@ chmod 600 ~/keys/my-wallet
 5. Use the `coda advanced wrap-key` tool to format your key pair into an importable format for the Mina client. Please note that using `coda advanced wrap-key` will force you to reset your password on your private key.
 
 ```
-mina advanced wrap-key -privkey-path ~/keys/my-wallet
+coda advanced wrap-key -privkey-path ~/keys/my-wallet
 ```
 
 You will be prompted for a new password, as shown below.
@@ -101,7 +119,6 @@ chmod 600 ~/keys/my-wallet
 7. Finally, we can import the account created by the client SDK into the client.
 
 ```
-ls ~/keys/
 coda accounts import -privkey-path ~/keys/my-wallet
 ```
 

--- a/pages/docs/keypair/index.mdx
+++ b/pages/docs/keypair/index.mdx
@@ -18,6 +18,11 @@ You can use your [Ledger Nano X or Nano S](https://www.ledger.com/) hardware wal
 
 Note: We are still iterating a bit on this process, so check back here every few days for updates!
 
+## Client SDK
+
+We've also created a client SDK that is able to generate key pairs and sign transactions. Please note that this method is unadvised and should only be used by experienced security professionals. Please use our [mina-generate-keypair](/docs/keypair/mina-generate-keypair) tool instead for creating key pairs.
+See our [client SDK documentation](/docs/keypair/client-sdk) for more information.
+
 <br />
 
 <Alert kind="warning">

--- a/src/components/DocsNavs.re
+++ b/src/components/DocsNavs.re
@@ -21,6 +21,7 @@ module SideNav = {
           <Item title="Keypair Overview" slug="" />
           <Item title="mina-generate-keypair" slug="mina-generate-keypair" />
           <Item title="ledger-app-mina" slug="ledger-app-mina" />
+          <Item title="client-sdk" slug="client-sdk" />
         </Section>
         <Item title="Connect to the Network" slug={f("connecting")} />
         <Item title="Tips for Node Operators" slug={f("node-operator")} />
@@ -110,6 +111,7 @@ module Dropdown = {
           | "keypair" => "Keypair Overview"
           | "keypair/mina-generate-keypair" => "mina-generate-keypair"
           | "keypair/ledger-app-mina" => "ledger-app-mina"
+          | "keypair/client-sdk" => "client-sdk"
 
           | "architecture" => "Mina Overview"
           | "architecture/lifecycle-payment" => "Lifecycle of a Payment"
@@ -144,6 +146,7 @@ module Dropdown = {
           <Item title="Keypair Overview" slug="" />
           <Item title="mina-generate-keypair" slug="mina-generate-keypair" />
           <Item title="ledger-app-mina" slug="ledger-app-mina" />
+          <Item title="client-sdk" slug="client-sdk" />
         </Section>
         <Item title="Connect to the Network" slug={f("connecting")} />
         <Item title="Tips for Node Operators" slug={f("node-operator")} />


### PR DESCRIPTION
This PR adds documentation on how to use the client-sdk to create a key pair and import that key-pair into our client. 