### PR TITLE
Hotfix: Apply bold styling in contentful content

### DIFF
--- a/src/pages/AnnouncementPost.re
+++ b/src/pages/AnnouncementPost.re
@@ -66,6 +66,7 @@ module Style = {
       selector("ul", [paddingLeft(`rem(1.))]),
       selector("ul > li", [paddingLeft(`rem(0.5))]),
       selector("ul > li > ul", [marginLeft(`rem(1.))]),
+      selector("strong", [fontWeight(`bold)]),
       selector(
         "img + em",
         [

--- a/src/pages/BlogPost.re
+++ b/src/pages/BlogPost.re
@@ -66,6 +66,7 @@ module Style = {
       selector("ul", [paddingLeft(`rem(1.))]),
       selector("ul > li", [paddingLeft(`rem(0.5))]),
       selector("ul > li > ul", [marginLeft(`rem(1.))]),
+      selector("strong", [fontWeight(`bold)]),
       selector(
         "img + em",
         [


### PR DESCRIPTION
The strong elements in the announcement and blog pages did not have proper bold styling. To fix this, explicitly added a bold style on strong elements.

**Before**
![image](https://user-images.githubusercontent.com/9512405/107681743-4f64f080-6c54-11eb-87f0-7e47ea2390ab.png)

**After**
![image](https://user-images.githubusercontent.com/9512405/107681678-365c3f80-6c54-11eb-84be-71f159d22319.png)