### PR TITLE
docs: updated mina-archive target release

### DIFF
--- a/pages/docs/archive-node.mdx
+++ b/pages/docs/archive-node.mdx
@@ -22,7 +22,7 @@ Let's get started by installing what we need.
 
     - Ubuntu/Debian:
       ```
-      sudo apt-get install -t unstable mina-archive
+      sudo apt-get install mina-archive=0.4.2-245a3f7
       ```
 
     - Docker: Use the same tag as in our documentation, but replace the image name


### PR DESCRIPTION
`apt` can't find the unstable release for the `mina-archive`, therefore as suggested by @bkase `mina-archive=0.4.2-245a3f7` should be the current working version for Zenith.

```
sudo apt-get install -t unstable mina-archive
Reading package lists... Done
E: The value 'unstable' is invalid for APT::Default-Release as such a release is not available in the sources
``` 