### PR TITLE
archive redundancy doc changes

### DIFF
--- a/pages/docs/architecture/timelock.mdx
+++ b/pages/docs/architecture/timelock.mdx
@@ -25,6 +25,46 @@ For a more technical explanaition of this process, please see [RFC-0025](https:/
 
 Along with time-locked accounts, we have introduced the notion of supercharged rewards. Once an account has no funds under time-lock (either a new account or the entire `initial_minimum_balance` has been vested) the block rewards are increased by a factor of 2x.
 
+### Liquid Balance Details:
+
+If you'd like to expose liquid balances for vesting accounts at some particular time period it is governed by the following function (Note: this computes the locked portion of an account):
+
+```
+(*
+ *  uint32 global_slot -- the "clock" it starts at 0 at the genesis block and ticks up every 3minutes.
+ *  uint32 cliff_time -- the slot where the cliff is (similar to startup equity vesting)
+ *  uint32 cliff_amount -- the amount that unlocks at the cliff
+ *  amount vesting_increment -- unlock this amount every "period"
+ *  uint32 vesting_period -- the period that we increment the unlocked amount
+ *  balance initial_minimum_balance -- the total locked amount until the cliff
+ *)
+let min_balance_at_slot ~global_slot ~cliff_time ~cliff_amount ~vesting_period
+    ~vesting_increment ~initial_minimum_balance =
+  let open Unsigned in
+  if Global_slot.(global_slot < cliff_time) then initial_minimum_balance
+  else
+    match Balance.(initial_minimum_balance - cliff_amount) with
+    | None ->
+        Balance.zero
+    | Some min_balance_past_cliff -> (
+        (* take advantage of fact that global slots are uint32's *)
+        let num_periods =
+          UInt32.(
+            Infix.((global_slot - cliff_time) / vesting_period)
+            |> to_int64 |> UInt64.of_int64)
+        in
+        let vesting_decrement =
+          UInt64.Infix.(num_periods * Amount.to_uint64 vesting_increment)
+          |> Amount.of_uint64
+        in
+        match Balance.(min_balance_past_cliff - vesting_decrement) with
+        | None ->
+            Balance.zero
+        | Some amt ->
+            amt )
+
+```
+
 ## Creating a time-locked account
 
 As of the current release, the only way to create a time-locked account is with the genesis ledger. In future releases we may add commands to `coda client` and the GraphQL API that will allow you to create a new time-locked account.

--- a/pages/docs/archive-node.mdx
+++ b/pages/docs/archive-node.mdx
@@ -74,7 +74,7 @@ coda daemon \
 Now that we've got the archive node running, let's take a look at the tables in the database. 
 
 To list the tables in the database, you can run the ``\dt`` command, in psql.
-View the full schema of the tables [here](https://github.com/minaProtocol/mina/blob/develop/src/app/archive/create_schema.sql).
+View the full schema of the tables [here](https://github.com/minaProtocol/mina/blob/master/src/app/archive/create_schema.sql).
 
 Below are some notable fields in each table. 
 

--- a/pages/docs/archive-redundancy.mdx
+++ b/pages/docs/archive-redundancy.mdx
@@ -3,13 +3,31 @@ export default Page({title: "Archive Redundancy"});
 
 # Archive Redundancy
 
-Presented here are three flows for accessing historical information about blocks and transactions.
+Archive data is critical for applications that require historical lookup. On the protocol side, archive data is important for disaster recovery in that it is needed to reconstruct a certain state. To that end, having a single [archive node setup](/docs/archive-node) might not be sufficient. If the daemon that sends blocks to the archive process or if the archive process itself fails for some reason, there can be missing blocks in the database. To minimize the risk of archive data loss there are a few redundancy techniques that can be employed.  
 
-The paths presented here are sorted from "rawest" to "most processed".
+A single archive node setup has a daemon sending blocks to an archive process which writes them to the database.
 
-O(1) labs will be deploying all three flows in their infrastructure (with lots of redundancy) so they will be able to provide missing information for consumers of (A), (B), or (C) if their nodes go offline for any reason and miss information.
+It is possible to connect multiple daemons to the archive process by specifying the address of an archive process in multiple daemons, thereby reducing the dependency on a single daemon to provide blocks to the archive process.
 
-## A. Raw Block Logging
+For example, the server-port of an archive process is 3086, then the daemons can connect to it using the flag `archive-address`
+
+```
+coda daemon \
+    .....
+  -archive-address <Ip-address>:3086\
+```
+
+Similarly, it is possible to have multiple archive processes write to the same database. In this case the postgres uri passed to the archive process would be same across multiple archive processes.
+
+However, multiple archive processes writing to a database concurrently could cause data inconsistencies (explained in https://github.com/MinaProtocol/mina/issues/7567). To avoid this, set the transaction isolation level of the archive database to `Serializable` using the following query:
+
+    ALTER DATABASE <DATABASE NAME> SET DEFAULT_TRANSACTION_ISOLATION TO SERIALIZABLE ;
+
+This should be done after creating the [database](/docs/archive-node) and before connecting an archive process to it.
+
+## Backing up block data
+
+To further ensure there that archive data can be restored one can use the following features to backup block data and restore them when necessary.
 
 We have a mechanism in place for logging a high-fidelity machine-readable representation of blocks using JSON including some opaque information deep within. We use these logs internally to quickly replay blocks to get to certain chain-states for debugging. This information suffices to recreate exact states of the network.
 
@@ -19,84 +37,55 @@ Some of the internal data look like this:
 {"data":["Signed_command",{"payload":{"common":{"fee":"100","fee_token":"1","fee_payer_pk":"B62qixbmBBmCmv1xH5SeF1hw6EqwSNVPi9B28epa3phqVMSyuZk9EoH","nonce":"340","valid_until":"4294967295","memo":"E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH"},"body":["Payment",{"source_pk":"B62qixbmBBmCmv1xH5SeF1hw6EqwSNVPi9B28epa3phqVMSyuZk9EoH","receiver_pk":"B62qm2GCuGCEK79mEjeyaeiFoukThuZLJCHGe9HAzuAnfbtS5FHtPnP","token_id":"1","amount":"100000000"}]},"signer":"B62qixbmBBmCmv1xH5SeF1hw6EqwSNVPi9B28epa3phqVMSyuZk9EoH","signature":"7mXGz8Df1gu92HVWGue24wcrGxDWkgQrDK59xQGXc627PKFQvVAPSzZn7JMkHtfdBUXavDHcgLBZy4iR4UmA5seRCPMkFDci"}],"status":["Applied",{"fee_payer_account_creation_fee_paid":null,"receiver_account_creation_fee_paid":null,"created_token":null},{"fee_payer_balance":"31866000100000","source_balance":"31866000100000","receiver_balance":"34099000000"}]}],"coinbase":["One",null],"internal_command_balances":[["Coinbase",{"coinbase_receiver_balance":"75477804514901","fee_transfer_receiver_balance":null}],["Fee_transfer",{"receiver1_balance":"65266376010003","receiver2_balance":"78601129170700"}],["Fee_transfer",{"receiver1_balance":"66001820000000","receiver2_balance":"76870784414900"}],["Fee_transfer",{"receiver1_balance":"71158365898775","receiver2_balance":"59264207944722"}],["Fee_transfer",{"receiver1_balance":"68546088449962","receiver2_balance":"66721919100000"}],["Fee_transfer",{"receiver1_balance":"67700798001000","receiver2_balance":"66372760000000"}],["Fee_transfer",{"receiver1_balance":"85383891400000","receiver2_balance":"107174952265469"}],["Fee_transfer",{"receiver1_balance":"65879310000000","receiver2_balance":"66282230000000"}]]}]},"delta_transition_chain_proof":["jxLZWooV57gKCmanzCHHt1CDbHfUpMu6MkynUdqN9ZkBUJi7B1W",[]]}
 ```
 
-This JSON will evolve as the format of the block and transaction payloads evolve in the network. Though we don't expect much churn before mainnet.
+This JSON will evolve as the format of the block and transaction payloads evolve in the network. Though we don't expect much churn before mainnet. This block data can be uploaded to a google storage bucket or written to mina.log files which can be backed-up separately.
 
-This information is exposed via a structured log and fed to stdout. We can supply filtering tooling for capturing just these messages so they can be safely and permanently stored.
+### Upload block data to google cloud storage
 
-## B. GraphQL JSON Snapshotting
+To indicate a daemon to upload block data to google cloud storage, pass the flag `--upload-blocks-to-gcloud` . To successfully upload the file, daemon requires the following environment variables to be set:
+    1. `GCLOUD_KEYFILE` : Key file for authentication
+    2. `NETWORK_NAME`: Network name to be used in the filename to easily distinguish between blocks in different networks (main-net and testnets)
+    3. `GCLOUD_BLOCK_UPLOAD_BUCKET` : Google cloud storage bucket where the files are uploaded
 
-The Mina daemon hosts a GraphQL server on port `0xc0d` or 3085 (by default, configurable via config file or -rest-server-port flag) to this machine (you can make it open to 0.0.0.0 with -insecure-reset-server). It is not safe for this port to be open to the public internet.
+The daemon generates a file for each block with the name `<network-name>-<protocol-state-hash>.json` . These are called precomputed blocks and will have all the fields of a block.
 
-We expose a `bestChain` query that will remain able to get *at least* the last few blocks (though not all of them) see the docs here for more: [https://minaprotocol.com/graphql-docs/query.doc.html](https://minaprotocol.com/graphql-docs/query.doc.html) that should have all the information you need in JSON. If you poll this at a rate faster than every 3minutes, you will keep up with every block. You can also get this same information via subscription pushed to you via [https://minaprotocol.com/graphql-docs/subscription.doc.html](https://minaprotocol.com/graphql-docs/subscription.doc.html) .
+### Save block data from logs
 
-Currently both many applications exist on testnets that consume this information. O(1) labs is relying on this data source in a few places and there will likely be other consumers by mainnet.
+The daemon also logs the block data if the flag `-log-precomputed-blocks` is passed. The log to look for is `Saw block with state hash $state_hash` that contains `precomputed_block` in the metadata and has the block information. This is the same information (precomputed blocks) that gets uploaded to google cloud storage.
 
-## C. Official Archive Node PostgreSQL
+### Generate block data from another archive database
 
-O(1) labs will support recovering missing data here from both (B) or (A) backups.
+From a fully synced archive database, one can generate block data for each block using the `mina-missing-subchain` tool. 
 
-The nice thing about the archive node is there are already consumers relying on queries for "what is the block at height N on the canonical chain". See [https://minaprotocol.com/docs/archive-node](https://minaprotocol.com/docs/archive-node) for more info.
+The tool takes an `--archive-uri`, an `--end-state-hash`, and an optional --start-state-hash and writes all the blocks in the chain starting from start-state-hash and ending at end-state-hash (including start and end).
 
-```
-WITH RECURSIVE chain AS (
-  (SELECT ... FROM blocks b WHERE height = (select MAX(height) from blocks)
-  ORDER BY timestamp ASC
-  LIMIT 1)
+If only the end hash is provided, then it generates blocks starting with the unparented block closest to the end block. This would be the genesis block if there are no missing blocks in between. The tool generates a file with name `<protocol-state-hash>.json` for each block. The block data in these files are called extensional blocks. Since these are generated from the database, they would have only the data stored in the archive database and would not contain any other information pertaining to a block (for example, blockchain snark) that the precomputed blocks would have and therefore, can only be used to restore blocks in the archive database.
 
-  UNION ALL
+## Identifying missing blocks
 
-  SELECT ... FROM blocks b
-  INNER JOIN chain
-  ON b.id = chain.parent_id AND chain.id <> chain.parent_id
-) SELECT ..., pk.value as creator FROM chain c
-  INNER JOIN public_keys pk
-  ON pk.id = c.creator_id
-  WHERE c.height = ?
+The tool `mina-missing-block-auditor` can be used to determine any missing blocks in an archive database. The tool outputs a list of state hashes of all the blocks in the database that are missing a parent. This can be used to monitor the archive database for any missing blocks. The URI of the postgres database can be specified using the flag `--archive-uri`
 
-```
+## Restoring blocks
 
-This can be tweaked to get all blocks within a window or all transactions within the blocks within a certain slice.
+Missing blocks in an archive database can be restored if there is block data (precomputed or extensional) available from the options listed [above](#Backing-up-block-data) using the tool `mina-archive-blocks`.
 
-===
-
-## Liquid Balance Details:
-
-All (A), (B), (C) have enough information to compute liquid balances for vesting accounts.
-
-If you'd like to expose liquid balances for vesting accounts at some particular time period it is governed by the following function (Note: this computes the locked portion of an account):
+1. Restore precomputed blocks: (from option [1](#Upload-block-data-to-google-cloud-storage) and [2](#Save-block-data-from-logs) above)
 
 ```
-(*  
- *  uint32 global_slot -- the "clock" it starts at 0 at the genesis block and ticks up every 3minutes.
- *  uint32 cliff_time -- the slot where the cliff is (similar to startup equity vesting)
- *  uint32 cliff_amount -- the amount that unlocks at the cliff
- *  amount vesting_increment -- unlock this amount every "period"
- *  uint32 vesting_period -- the period that we increment the unlocked amount
- *  balance initial_minimum_balance -- the total locked amount until the cliff
- *)
-let min_balance_at_slot ~global_slot ~cliff_time ~cliff_amount ~vesting_period
-    ~vesting_increment ~initial_minimum_balance =
-  let open Unsigned in
-  if Global_slot.(global_slot < cliff_time) then initial_minimum_balance
-  else
-    match Balance.(initial_minimum_balance - cliff_amount) with
-    | None ->
-        Balance.zero
-    | Some min_balance_past_cliff -> (
-        (* take advantage of fact that global slots are uint32's *)
-        let num_periods =
-          UInt32.(
-            Infix.((global_slot - cliff_time) / vesting_period)
-            |> to_int64 |> UInt64.of_int64)
-        in
-        let vesting_decrement =
-          UInt64.Infix.(num_periods * Amount.to_uint64 vesting_increment)
-          |> Amount.of_uint64
-        in
-        match Balance.(min_balance_past_cliff - vesting_decrement) with
-        | None ->
-            Balance.zero
-        | Some amt ->
-            amt )
+  mina-archive-blocks --precomputed --archive-uri <postgres uri> FILES
+```
+
+2. For extensional blocks: (Generated from option [3](#Generate-block-data-from-another-archive-database))
 
 ```
+  mina-archive-blocks --extensional --archive-uri <postgres uri> FILES
+```
+
+## Staking ledgers
+
+Staking ledgers are used to determine slot winners for each epoch. Mina daemon stores staking ledger for the current and the next epoch (after it is finalized). When transitioning to a new epoch, the "next" staking ledger from the previous epoch is used to determine slot winners of the new epoch and a new "next" staking ledger is chosen. Since staking ledgers for older epochs are no longer accessible, users may want to still keep them around for reporting or other purposes.
+
+Currently these ledgers can be exported using the cli command-
+
+    coda ledger export [current-staged-ledger|staking-epoch-ledger|next-epoch-ledger]
+
+Epoch ledger transition happens once every 14 days (given slot-time = 3mins and slots-per-epoch = 7140). The window to backup a staking ledger is ~27 days considering "next" staking ledger is finalized after k (currently 290) blocks in the current epoch and therefore will be available for the rest of the current epoch and the entire next epoch.


### PR DESCRIPTION
Merged changes from this PR https://github.com/MinaProtocol/mina/pull/7864. Also, moved locked tokens calculation to the timing page

I omitted the images that shows the archive node setup. Not sure how we want to align/size them in the webpage