### PR TITLE
Feature: Press links open in new tab + security fixes

### DIFF
--- a/src/components/Button.re
+++ b/src/components/Button.re
@@ -90,7 +90,11 @@ module Link = {
     switch (href) {
     | `Scroll_to_top => <Next.Link href=""> children </Next.Link>
     | `External(href) =>
-      <a className=Css.(style([textDecoration(`none)])) href target="_blank">
+      <a
+        className=Css.(style([textDecoration(`none)]))
+        href
+        target="_blank"
+        rel="noopener">
         children
       </a>
     | `Internal(href) => <Next.Link href> children </Next.Link>

--- a/src/components/ButtonBar.re
+++ b/src/components/ButtonBar.re
@@ -66,7 +66,9 @@ module Card = {
     | `Internal(href) => <Next.Link href> inner </Next.Link>
     | `External(href) => <a href className=Styles.anchor> inner </a>
     | `NewTab(href) =>
-      <a target="_blank" href className=Styles.anchor> inner </a>
+      <a target="_blank" rel="noopener" href className=Styles.anchor>
+        inner
+      </a>
     };
   };
 };
@@ -97,7 +99,9 @@ module CardDarkGray = {
     | `Internal(href) => <Next.Link href> inner </Next.Link>
     | `External(href) => <a href className=Styles.anchor> inner </a>
     | `NewTab(href) =>
-      <a target="_blank" href className=Styles.anchor> inner </a>
+      <a target="_blank" rel="noopener" href className=Styles.anchor>
+        inner
+      </a>
     };
   };
 };
@@ -135,7 +139,9 @@ module CardLightGray = {
     | `Internal(href) => <Next.Link href> inner </Next.Link>
     | `External(href) => <a href className=Styles.anchor> inner </a>
     | `NewTab(href) =>
-      <a target="_blank" href className=Styles.anchor> inner </a>
+      <a target="_blank" rel="noopener" href className=Styles.anchor>
+        inner
+      </a>
     };
   };
 };

--- a/src/components/CarouselCards.re
+++ b/src/components/CarouselCards.re
@@ -161,6 +161,7 @@ module GenesisMemberCard = {
              | Some(twitter) =>
                <a
                  target="_blank"
+                 rel="noopener"
                  href={Constants.twitterUrl ++ twitter}
                  className={Styles.iconLink(dark)}>
                  <Icon kind=Icon.Twitter />
@@ -171,6 +172,7 @@ module GenesisMemberCard = {
              | Some(github) =>
                <a
                  target="_blank"
+                 rel="noopener"
                  href={Constants.githubUrl ++ github}
                  className={Styles.iconLink(dark)}>
                  <Icon kind=Icon.Github />
@@ -263,6 +265,7 @@ module TeamMemberCard = {
              | Some(twitter) =>
                <a
                  target="_blank"
+                 rel="noopener"
                  href={Constants.twitterUrl ++ twitter}
                  className={Styles.iconLink(dark)}>
                  <Icon kind=Icon.Twitter />
@@ -273,6 +276,7 @@ module TeamMemberCard = {
              | Some(github) =>
                <a
                  target="_blank"
+                 rel="noopener"
                  href={Constants.githubUrl ++ github}
                  className={Styles.iconLink(dark)}>
                  <Icon kind=Icon.Github />
@@ -283,6 +287,7 @@ module TeamMemberCard = {
              | Some(linkedIn) =>
                <a
                  target="_blank"
+                 rel="noopener"
                  href={Constants.linkedInUrl ++ linkedIn}
                  className={Styles.iconLink(dark)}>
                  <Icon kind=Icon.LinkedIn />

--- a/src/components/DocsComponents.re
+++ b/src/components/DocsComponents.re
@@ -125,7 +125,12 @@ module P =
 
 module A =
   Wrap({
-    let element = <a className={merge([Styles.link, Theme.Type.link])} />;
+    let element =
+      <a
+        target="_blank"
+        rel="noopener"
+        className={merge([Styles.link, Theme.Type.link])}
+      />;
   });
 
 module Strong =

--- a/src/components/KnowledgeBase.re
+++ b/src/components/KnowledgeBase.re
@@ -24,7 +24,8 @@ module Resource = {
     <a
       href={resource.url}
       className=Css.(style([textDecoration(`none)]))
-      target="_blank">
+      target="_blank"
+      rel="noopener">
       <div className=Styles.resource>
         <img src={resource.image.fields.file.url} />
         <Spacer height=1. />

--- a/src/components/ListModule.re
+++ b/src/components/ListModule.re
@@ -165,7 +165,13 @@ module MainListing = {
        switch (item.link) {
        | `Slug(slug) => renderInternalLinkKind(itemKind, slug, inner)
        | `Remote(href) =>
-         <a target="_blank" className=MainListingStyles.anchor href> inner </a>
+         <a
+           target="_blank"
+           rel="noopener"
+           className=MainListingStyles.anchor
+           href>
+           inner
+         </a>
        }}
     </div>;
   };
@@ -193,7 +199,13 @@ module Listing = {
       switch (item.link) {
       | `Slug(slug) => renderInternalLinkKind(itemKind, slug, inner)
       | `Remote(href) =>
-        <a target="_blank" className=MainListing.MainListingStyles.anchor href> inner </a>
+        <a
+          target="_blank"
+          rel="noopener"
+          className=MainListing.MainListingStyles.anchor
+          href>
+          inner
+        </a>
       };
     };
 

--- a/src/components/ListModule.re
+++ b/src/components/ListModule.re
@@ -165,7 +165,7 @@ module MainListing = {
        switch (item.link) {
        | `Slug(slug) => renderInternalLinkKind(itemKind, slug, inner)
        | `Remote(href) =>
-         <a className=MainListingStyles.anchor href> inner </a>
+         <a target="_blank" className=MainListingStyles.anchor href> inner </a>
        }}
     </div>;
   };
@@ -193,7 +193,7 @@ module Listing = {
       switch (item.link) {
       | `Slug(slug) => renderInternalLinkKind(itemKind, slug, inner)
       | `Remote(href) =>
-        <a className=MainListing.MainListingStyles.anchor href> inner </a>
+        <a target="_blank" className=MainListing.MainListingStyles.anchor href> inner </a>
       };
     };
 

--- a/src/components/ProfileCard.re
+++ b/src/components/ProfileCard.re
@@ -163,6 +163,7 @@ let make =
            | Some(twitter) =>
              <a
                target="_blank"
+               rel="noopener"
                href={Constants.twitterUrl ++ twitter}
                className=Styles.iconLink>
                <Icon kind=Icon.Twitter />
@@ -173,6 +174,7 @@ let make =
            | Some(github) =>
              <a
                target="_blank"
+               rel="noopener"
                href={Constants.githubUrl ++ github}
                className=Styles.iconLink>
                <Icon kind=Icon.Github />
@@ -181,7 +183,11 @@ let make =
            }}
           {switch (member.linkedin) {
            | Some(linkedIn) =>
-             <a target="_blank" href=linkedIn className=Styles.iconLink>
+             <a
+               target="_blank"
+               rel="noopener"
+               href=linkedIn
+               className=Styles.iconLink>
                <Icon kind=Icon.LinkedIn />
              </a>
            | _ => React.null

--- a/src/components/StatusBadge.re
+++ b/src/components/StatusBadge.re
@@ -155,7 +155,7 @@ module Inner = {
         )
       };
     };
-    <a href=url className=Styles.link target="_blank">
+    <a href=url className=Styles.link target="_blank" rel="noopener">
       <span className={Styles.wrapper(bgColor, fgColor)}>
         <span className=Styles.statusCircle />
         <span className=Styles.statusBadge__label>

--- a/src/pages/Docs.re
+++ b/src/pages/Docs.re
@@ -117,6 +117,7 @@ module EditLink = {
     <a
       name="Edit Link"
       target="_blank"
+      rel="noopener"
       href={Constants.minaDocsEditLink ++ route ++ ".mdx"}
       className=Style.editLink>
       <span className=Theme.Type.link> {React.string("Edit ")} </span>


### PR DESCRIPTION
This PR implements the following

1. Security fixes related to `target='_blank'`
2. Made Press module links open in a new tab
3. Made all blog links open in a new tab