### PR TITLE
Docs: Update CLI Reference docs

### DIFF
--- a/pages/docs/cli-reference.mdx
+++ b/pages/docs/cli-reference.mdx
@@ -9,11 +9,9 @@ The CLI is installed when you [install mina](/docs/getting-started#installation)
 
 <Alert kind="warning">
 
-
 Mina APIs are still under construction, so these commands will likely change. See `mina help` for the most up-to-date version.
 
 </Alert>
-
 
 ### Mina Accounts
 
@@ -29,11 +27,11 @@ Client commands concerning account management
   list    List all owned accounts
   create  Create new account
   import  Import a password protected private key to be tracked by the daemon.
-          Set MINA_PRIVKEY_PASS environment variable to use non-interactively
+          Set CODA_PRIVKEY_PASS environment variable to use non-interactively
           (key will be imported using the same password).
   export  Export a tracked account so that it can be saved or transferred
           between machines.
-          Set MINA_PRIVKEY_PASS environment variable to use non-interactively
+          Set CODA_PRIVKEY_PASS environment variable to use non-interactively
           (key will be exported using the same password).
   unlock  Unlock a tracked account
   lock    Lock a tracked account
@@ -51,19 +49,25 @@ Lightweight client commands
 
 === subcommands ===
 
-  get-balance         Get balance associated with a public key
-  send-payment        Send payment to an address
-  delegate-stake      Delegate your stake to another public key
-  cancel-transaction  Cancel a transaction -- this submits a replacement
-                      transaction with a fee larger than the cancelled
-                      transaction.
-  set-staking         Start producing blocks
-  set-snark-worker    Set key you wish to snark work with or disable snark
-                      working
-  set-snark-work-fee  Set fee reward for doing transaction snark work
-  stop-daemon         Stop the daemon
-  status              Get running daemon status
-  help                explain a given subcommand (perhaps recursively)
+  get-balance           Get balance associated with a public key
+  get-tokens            Get all token IDs that a public key has accounts for
+  send-payment          Send payment to an address
+  delegate-stake        Delegate your stake to another public key
+  create-token          Create a new token
+  create-token-account  Create a new account for a token
+  mint-tokens           Mint more of a token owned by the command's sender
+  cancel-transaction    Cancel a transaction -- this submits a replacement
+                        transaction with a fee larger than the cancelled
+                        transaction.
+  set-staking           Start producing blocks
+  set-snark-worker      Set key you wish to snark work with or disable snark
+                        working
+  set-snark-work-fee    Set fee reward for doing transaction snark work
+  export-logs           Export daemon logs to tar archive
+  export-local-logs     Export local logs (no daemon) to tar archive
+  stop-daemon           Stop the daemon
+  status                Get running daemon status
+  help                  explain a given subcommand (perhaps recursively)
 ```
 
 ### Mina Daemon
@@ -77,117 +81,317 @@ Mina daemon
 
 === flags ===
 
-  [-archive-address HOST:PORT/LOCALHOST-PORT]  Daemon to archive process
-                                               communication. If HOST is
-                                               omitted, then localhost is
-                                               assumed to be HOST. (examples:
-                                               3086, 154.97.53.97:3086)
-  [-archive-rocksdb]                           Stores all the blocks heard in
-                                               RocksDB
-  [-background]                                Run process on the background
-  [-bind-ip IP]                                IP of network interface to use
-                                               for peer connections
-  [-block-producer-key KEYFILE]                Private key file for the block
-                                               producer. You cannot provide both
-                                               `block-producer-key` and
-                                               `block-producer-pubkey`.
-                                               (default: don't produce blocks)
-  [-block-producer-password PASSWORD]          Password associated with the
-                                               block-producer key. Setting this
-                                               is equivalent to setting the
-                                               MINA_PRIVKEY_PASS environment
-                                               variable. Be careful when setting
-                                               it in the commandline as it will
-                                               likely get tracked in your
-                                               history. Mainly to be used from
-                                               the daemon.json config file
-  [-block-producer-pubkey PUBLICKEY]           Public key for the associated
-                                               private key that is being tracked
-                                               by this daemon. You cannot
-                                               provide both `block-producer-key`
-                                               and `block-producer-pubkey`.
-                                               (default: don't produce blocks)
-  [-client-port PORT]                          local RPC-server for clients to
-                                               interact with the daemon
-                                               (default: 8301)
-  [-coinbase-receiver PUBLICKEY]               Address to send coinbase rewards
-                                               to (if this node is producing
-                                               blocks). If not provided,
-                                               coinbase rewards will be sent to
-                                               the producer of a block.
-  [-config-directory DIR]                      Configuration directory
-  [-current-fork-id HEX-STRING]                (5 characters) Current fork ID
-                                               for this node, only blocks with
-                                               the same ID accepted
-  [-demo-mode]                                 Run the daemon in demo-mode --
-                                               assume we're "synced" to the
-                                               network instantly
-  [-discovery-keypair KEYFILE]                 Keypair (generated from `mina
-                                               advanced
-                                               generate-libp2p-keypair`) to use
-                                               with libp2p discovery (default:
-                                               generate per-run temporary
-                                               keypair)
-  [-external-ip IP]                            External IP address for other
-                                               nodes to connect to. You only
-                                               need to set this if
-                                               auto-discovery fails for some
-                                               reason.
-  [-external-port PORT]                        Port to use for all libp2p
-                                               communications (gossip and RPC)
-                                               (default: 8302)
-  [-genesis-ledger-dir DIR]                    Directory that contains the
-                                               genesis ledger and the genesis
-                                               blockchain proof (default:
-                                               <config-dir>/genesis-ledger)
-  [-insecure-rest-server]                      Have REST server listen on all
-                                               addresses, not just localhost
-                                               (this is INSECURE, make sure your
-                                               firewall is configured
-                                               correctly!)
-  [-log-block-creation true|false]             Log the steps involved in
-                                               including transactions and snark
-                                               work in a block (default: true)
-  [-log-json]                                  Print log output as JSON
-                                               (default: plain text)
-  [-log-level Set]                             log level (default: Info)
-  [-log-received-blocks true|false]            Log blocks received from peers
-                                               (default: false)
-  [-log-snark-work-gossip true|false]          Log snark-pool diff received from
-                                               peers (default: false)
-  [-log-txn-pool-gossip true|false]            Log transaction-pool diff
-                                               received from peers (default:
-                                               false)
-  [-metrics-port PORT]                         metrics server for scraping via
-                                               Prometheus (default no
-                                               metrics-server)
-  [-peer /ip4/IPADDR/tcp/PORT/p2p/PEERID]     initial "bootstrap" peers for
-                                               discovery
-  [-rest-port PORT]                            local REST-server for daemon
-                                               interaction (default: 3085)
-  [-run-snark-worker PUBLICKEY]                Run the SNARK worker with this
-                                               public key
-  [-seed]                                      Start the node as a seed node
-  [-snark-worker-fee FEE]                      Amount a worker wants to get
-                                               compensated for generating a
-                                               snark proof (default: 1000000000)
-  [-snark-worker-parallelism NUM]              Run the SNARK worker using this
-                                               many threads. Equivalent to
-                                               setting OMP_NUM_THREADS, but
-                                               doesn't affect block production.
-  [-tracing]                                   Trace into
-                                               $config-directory/$pid.trace
-  [-work-reassignment-wait WAIT-TIME]          in ms before a snark-work is
-                                               reassigned (default: 420000ms)
-  [-work-selection seq|rand]                   Choose work sequentially (seq) or
-                                               randomly (rand) (default: rand)
-  [-working-dir PATH]                          path to chdir into before
-                                               starting (useful for background
-                                               mode, defaults to cwd, or / if
-                                               -background)
-  [-help]                                      print this help text and exit
-                                               (alias: -?)
-
+   [--archive-address HOST:PORT/LOCALHOST-PORT]       Daemon to archive process
+                                                      communication. If HOST is
+                                                      omitted, then localhost is
+                                                      assumed to be HOST.
+                                                      (examples: 3086,
+                                                      154.97.53.97:3086)
+                                                      (alias: -archive-address)
+  [--archive-rocksdb]                                 Stores all the blocks
+                                                      heard in RocksDB
+                                                      (alias: -archive-rocksdb)
+  [--background]                                      Run process on the
+                                                      background
+                                                      (alias: -background)
+  [--bind-ip IP]                                      IP of network interface to
+                                                      use for peer connections
+                                                      (alias: -bind-ip)
+  [--block-producer-key KEYFILE]                      Private key file for the
+                                                      block producer. You cannot
+                                                      provide both
+                                                      `block-producer-key` and
+                                                      `block-producer-pubkey`.
+                                                      (default: don't produce
+                                                      blocks)
+                                                      (alias:
+                                                      -block-producer-key)
+  [--block-producer-password PASSWORD]                Password associated with
+                                                      the block-producer key.
+                                                      Setting this is equivalent
+                                                      to setting the
+                                                      CODA_PRIVKEY_PASS
+                                                      environment variable. Be
+                                                      careful when setting it in
+                                                      the commandline as it will
+                                                      likely get tracked in your
+                                                      history. Mainly to be used
+                                                      from the daemon.json
+                                                      config file
+                                                      (alias:
+                                                      -block-producer-password)
+  [--block-producer-pubkey PUBLICKEY]                 Public key for the
+                                                      associated private key
+                                                      that is being tracked by
+                                                      this daemon. You cannot
+                                                      provide both
+                                                      `block-producer-key` and
+                                                      `block-producer-pubkey`.
+                                                      (default: don't produce
+                                                      blocks)
+                                                      (alias:
+                                                      -block-producer-pubkey)
+  [--client-port PORT]                                local RPC-server for
+                                                      clients to interact with
+                                                      the daemon (default: 8301)
+                                                      (alias: -client-port)
+  [--coinbase-receiver PUBLICKEY]                     Address to send coinbase
+                                                      rewards to (if this node
+                                                      is producing blocks). If
+                                                      not provided, coinbase
+                                                      rewards will be sent to
+                                                      the producer of a block.
+                                                      (alias:
+                                                      -coinbase-receiver)
+  [--config-directory DIR]                            Configuration directory
+                                                      (alias: -config-directory)
+  [--config-file PATH]                                path to a configuration
+                                                      file (overrides
+                                                      CODA_CONFIG_FILE, default:
+                                                      <config_dir>/daemon.json).
+                                                      Pass multiple times to
+                                                      override fields from
+                                                      earlier config files
+                                                      (alias: -config-file)
+  [--current-protocol-version NN.NN.NN]               Current protocol version,
+                                                      only blocks with the same
+                                                      version accepted
+                                                      (alias:
+                                                      -current-protocol-version)
+  [--demo-mode]                                       Run the daemon in
+                                                      demo-mode -- assume we're
+                                                      "synced" to the network
+                                                      instantly
+                                                      (alias: -demo-mode)
+  [--direct-peer /ip4/IPADDR/tcp/PORT/p2p/PEERID]     Peers to always send new
+                                                      messages to/from. These
+                                                      peers should also have you
+                                                      configured as a direct
+                                                      peer, the relationship is
+                                                      intended to be symmetric
+                                                      (alias: -direct-peer)
+  [--disable-telemetry]                               Disable reporting
+                                                      telemetry to other nodes
+                                                      (alias:
+                                                      -disable-telemetry)
+  [--discovery-keypair KEYFILE]                       Keypair (generated from
+                                                      `coda advanced
+                                                      generate-libp2p-keypair`)
+                                                      to use with libp2p
+                                                      discovery (default:
+                                                      generate per-run temporary
+                                                      keypair)
+                                                      (alias:
+                                                      -discovery-keypair)
+  [--enable-flooding true|false]                      Publish our own
+                                                      blocks/transactions to
+                                                      every peer we can find
+                                                      (default: false)
+                                                      (alias: -enable-flooding)
+  [--enable-mina-peer-exchange true|false]            Help keep the mesh
+                                                      connected when closing
+                                                      connections (default:
+                                                      true)
+                                                      (alias:
+                                                      -enable-mina-peer-exchange)
+  [--enable-peer-exchange true|false]                 Help keep the mesh
+                                                      connected when closing
+                                                      connections (default:
+                                                      false)
+                                                      (alias:
+                                                      -enable-peer-exchange)
+  [--external-ip IP]                                  External IP address for
+                                                      other nodes to connect to.
+                                                      You only need to set this
+                                                      if auto-discovery fails
+                                                      for some reason.
+                                                      (alias: -external-ip)
+  [--external-port PORT]                              Port to use for all libp2p
+                                                      communications (gossip and
+                                                      RPC) (default: 8302)
+                                                      (alias: -external-port)
+  [--file-log-level LEVEL]                            Set log level for the log
+                                                      file
+                                                      (Spam|Trace|Debug|Info|Warn|Error|Faulty_peer|Fatal,
+                                                      default: Trace)
+                                                      (alias: -file-log-level)
+  [--generate-genesis-proof true|false]               Generate a new genesis
+                                                      proof for the current
+                                                      configuration if none is
+                                                      found (default: false)
+                                                      (alias:
+                                                      -generate-genesis-proof)
+  [--genesis-ledger-dir DIR]                          Directory that contains
+                                                      the genesis ledger and the
+                                                      genesis blockchain proof
+                                                      (default: <config-dir>)
+                                                      (alias:
+                                                      -genesis-ledger-dir)
+  [--insecure-rest-server]                            Have REST server listen on
+                                                      all addresses, not just
+                                                      localhost (this is
+                                                      INSECURE, make sure your
+                                                      firewall is configured
+                                                      correctly!)
+                                                      (alias:
+                                                      -insecure-rest-server)
+  [--isolate-network true|false]                      Only allow connections to
+                                                      the peers passed on the
+                                                      command line or configured
+                                                      through GraphQL. (default:
+                                                      false)
+                                                      (alias: -isolate-network)
+  [--libp2p-metrics-port PORT]                        libp2p metrics server for
+                                                      scraping via Prometheus
+                                                      (default no
+                                                      libp2p-metrics-server)
+                                                      (alias:
+                                                      -libp2p-metrics-port)
+  [--log-block-creation true|false]                   Log the steps involved in
+                                                      including transactions and
+                                                      snark work in a block
+                                                      (default: true)
+                                                      (alias:
+                                                      -log-block-creation)
+  [--log-json]                                        Print log output as JSON
+                                                      (default: plain text)
+                                                      (alias: -log-json)
+  [--log-level LEVEL]                                 Set log level
+                                                      (Spam|Trace|Debug|Info|Warn|Error|Faulty_peer|Fatal,
+                                                      default: Info)
+                                                      (alias: -log-level)
+  [--log-precomputed-blocks true|false]               Include precomputed blocks
+                                                      in the log (default:
+                                                      false)
+                                                      (alias:
+                                                      -log-precomputed-blocks)
+  [--log-snark-work-gossip true|false]                Log snark-pool diff
+                                                      received from peers
+                                                      (default: false)
+                                                      (alias:
+                                                      -log-snark-work-gossip)
+  [--log-txn-pool-gossip true|false]                  Log transaction-pool diff
+                                                      received from peers
+                                                      (default: false)
+                                                      (alias:
+                                                      -log-txn-pool-gossip)
+  [--max-connections NN]                              max number of connections
+                                                      that this peer will have
+                                                      to neighbors in the gossip
+                                                      network. Tuning this
+                                                      higher will strengthen
+                                                      your connection to the
+                                                      network in exchange for
+                                                      using more RAM (default:
+                                                      50)
+                                                      (alias: -max-connections)
+  [--metrics-port PORT]                               metrics server for
+                                                      scraping via Prometheus
+                                                      (default no
+                                                      metrics-server)
+                                                      (alias: -metrics-port)
+  [--no-super-catchup]                                Don't use super-catchup
+                                                      (alias: -no-super-catchup)
+  [--peer /ip4/IPADDR/tcp/PORT/p2p/PEERID]            initial "bootstrap" peers
+                                                      for discovery
+                                                      (alias: -peer)
+  [--peer-list-file /ip4/IPADDR/tcp/PORT/p2p/PEERID]  initial "bootstrap" peers
+                                                      for discovery inside a
+                                                      file delimited by
+                                                      new-lines (\n)
+                                                      (alias: -peer-list-file)
+  [--peer-list-url URL]                               URL of seed peer list
+                                                      file. Will be polled
+                                                      periodically.
+                                                      (alias: -peer-list-url)
+  [--precomputed-blocks-file PATH]                    Path to write precomputed
+                                                      blocks to, for replay or
+                                                      archiving
+                                                      (alias:
+                                                      -precomputed-blocks-file)
+  [--proof-level]                                     full|check|none
+                                                      (alias: -proof-level)
+  [--proposed-protocol-version NN.NN.NN]              Proposed protocol version
+                                                      to signal other nodes
+                                                      (alias:
+                                                      -proposed-protocol-version)
+  [--rest-port PORT]                                  local REST-server for
+                                                      daemon interaction
+                                                      (default: 3085)
+                                                      (alias: -rest-port)
+  [--run-snark-coordinator PUBLICKEY]                 Run a SNARK coordinator
+                                                      with this public key
+                                                      (ignored if the
+                                                      run-snark-worker is set)
+                                                      (alias:
+                                                      -run-snark-coordinator)
+  [--run-snark-worker PUBLICKEY]                      Run the SNARK worker with
+                                                      this public key
+                                                      (alias: -run-snark-worker)
+  [--seed]                                            Start the node as a seed
+                                                      node
+                                                      (alias: -seed)
+  [--snark-worker-fee FEE]                            Amount a worker wants to
+                                                      get compensated for
+                                                      generating a snark proof
+                                                      (default: 100000000)
+                                                      (alias: -snark-worker-fee)
+  [--snark-worker-parallelism NUM]                    Run the SNARK worker using
+                                                      this many threads.
+                                                      Equivalent to setting
+                                                      OMP_NUM_THREADS, but
+                                                      doesn't affect block
+                                                      production.
+                                                      (alias:
+                                                      -snark-worker-parallelism)
+  [--tracing]                                         Trace into
+                                                      $config-directory/trace/$pid.trace
+                                                      (alias: -tracing)
+  [--upload-blocks-to-gcloud true|false]              upload blocks to gcloud
+                                                      storage. Requires the
+                                                      environment variables
+                                                      GCLOUD_KEYFILE,
+                                                      NETWORK_NAME, and
+                                                      GCLOUD_BLOCK_UPLOAD_BUCKET
+                                                      (alias:
+                                                      -upload-blocks-to-gcloud)
+  [--validation-queue-size NN]                        size of the validation
+                                                      queue in the p2p network
+                                                      used to buffer messages
+                                                      (like blocks and
+                                                      transactions received on
+                                                      the gossip network) while
+                                                      validation is pending. If
+                                                      a transaction, for
+                                                      example, is invalid, we
+                                                      don't forward the message
+                                                      on the gossip net. If this
+                                                      queue is too small, we
+                                                      will drop messages without
+                                                      validating them. If it is
+                                                      too large, we are
+                                                      susceptible to DoS attacks
+                                                      on memory. (default: 150)
+                                                      (alias:
+                                                      -validation-queue-size)
+  [--work-reassignment-wait WAIT-TIME]                in ms before a snark-work
+                                                      is reassigned (default:
+                                                      420000ms)
+                                                      (alias:
+                                                      -work-reassignment-wait)
+  [--work-selection seq|rand]                         Choose work sequentially
+                                                      (seq) or randomly (rand)
+                                                      (default: rand)
+                                                      (alias: -work-selection)
+  [--working-dir PATH]                                path to chdir into before
+                                                      starting (useful for
+                                                      background mode, defaults
+                                                      to cwd, or / if
+                                                      -background)
+                                                      (alias: -working-dir)
+  [-help]                                             print this help text and
+                                                      exit
+                                                      (alias: -?)
 
 ```
 

--- a/pages/docs/cli-reference.mdx
+++ b/pages/docs/cli-reference.mdx
@@ -81,7 +81,7 @@ Mina daemon
 
 === flags ===
 
-   [--archive-address HOST:PORT/LOCALHOST-PORT]       Daemon to archive process
+  [--archive-address HOST:PORT/LOCALHOST-PORT]        Daemon to archive process
                                                       communication. If HOST is
                                                       omitted, then localhost is
                                                       assumed to be HOST.

--- a/pages/docs/cli-reference.mdx
+++ b/pages/docs/cli-reference.mdx
@@ -406,38 +406,57 @@ Advanced client commands
 
 === subcommands ===
 
-  batch-send-payments        Send multiple payments from a file
-  client-trustlist           Client trustlist management
-  compile-time-constants     Print a JSON map of the compile-time consensus
-                             parameters
-  constraint-system-digests  Print MD5 digest of each SNARK constraint
-  dump-keypair               Print out a keypair from a private key file
-  dump-ledger                Print the ledger with given Merkle root
-  generate-keypair           Generate a new public-key/private-key pair
-  generate-libp2p-keypair    Generate a new libp2p keypair and print out the
-                             peer ID
-  generate-receipt           Generate a receipt for a sent payment
-  get-nonce                  Get the current nonce for an account
-  get-public-keys            Get public keys
-  get-trust-status           Get the trust status associated with an IP address
-  get-trust-status-all       Get trust statuses for all peers known to the trust
-                             system
-  pending-snark-work         List of snark works in JSON format that are not
-                             available in the pool yet
-  pooled-user-commands       Retrieve all the user commands that are pending
-                             inclusion
-  reset-trust-status         Reset the trust status associated with an IP
-                             address
-  snark-job-list             List of snark jobs in JSON format that are yet to
-                             be included in the blocks
-  snark-pool-list            List of snark works in the snark pool in JSON
-                             format
-  start-tracing              Start async tracing to $config-directory/$pid.trace
-  status-clear-hist          Clear histograms reported in status
-  stop-tracing               Stop async tracing
-  telemetry                  Get the trust status associated with an IP address
-  verify-receipt             Verify a receipt of a sent payment
-  visualization              Visualize data structures special to Mina
-  wrap-key                   Wrap a private key into a private key file
-  help                       explain a given subcommand (perhaps recursively)
+  add-peers                   Add peers to the daemon
+                              Addresses take the format
+                              /ip4/IPADDR/tcp/PORT/p2p/PEERID
+  archive-blocks              Archive a block from a file.
+                              If an archive address is given, this process will
+                              communicate with the archive node directly;
+                              otherwise it will communicate through the daemon
+                              over the rest-server
+  batch-send-payments         Send multiple payments from a file
+  client-trustlist            Client trustlist management
+  compile-time-constants      Print a JSON map of the compile-time consensus
+                              parameters
+  compute-receipt-chain-hash  Compute the next receipt chain hash from the
+                              previous hash and transaction ID
+  constraint-system-digests   Print MD5 digest of each SNARK constraint
+  dump-keypair                Print out a keypair from a private key file
+  generate-keypair            Generate a new public, private keypair
+  generate-libp2p-keypair     Generate a new libp2p keypair and print out the
+                              peer ID
+  get-nonce                   Get the current nonce for an account
+  get-peers                   List the peers currently connected to the daemon
+  get-public-keys             Get public keys
+  get-trust-status            Get the trust status associated with an IP address
+  get-trust-status-all        Get trust statuses for all peers known to the
+                              trust system
+  next-available-token        The next token ID that has not been allocated.
+                              Token IDs are allocated sequentially, so all lower
+                              token IDs have been allocated
+  object-lifetime-statistics  Dump internal object lifetime statistics to JSON
+  pending-snark-work          List of snark works in JSON format that are not
+                              available in the pool yet
+  pooled-user-commands        Retrieve all the user commands that are pending
+                              inclusion
+  reset-trust-status          Reset the trust status associated with an IP
+                              address
+  snark-job-list              List of snark jobs in JSON format that are yet to
+                              be included in the blocks
+  snark-pool-list             List of snark works in the snark pool in JSON
+                              format
+  start-tracing               Start async tracing to
+                              $config-directory/trace/$pid.trace
+  status-clear-hist           Clear histograms reported in status
+  stop-tracing                Stop async tracing
+  telemetry                   Get telemetry data for a set of peers
+  time-offset                 Get the time offset in seconds used by the daemon
+                              to convert real time into blockchain time
+  validate-keypair            Validate a public, private keypair
+  validate-transaction        Validate the signature on one or more
+                              transactions, provided to stdin in rosetta format
+  verify-receipt              Verify a receipt of a sent payment
+  visualization               Visualize data structures special to Coda
+  wrap-key                    Wrap a private key into a private key file
+  help                        explain a given subcommand (perhaps recursively)
 ```


### PR DESCRIPTION
Used docker build `gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-zenith-7a89538` to regenerate the docs with the new commands implemented since the last build the CLI docs referenced.