### PR TITLE
Remove Rust Client Grant & Misc Fixes

### DIFF
--- a/pages/docs/advanced/connecting-devnet.mdx
+++ b/pages/docs/advanced/connecting-devnet.mdx
@@ -8,11 +8,7 @@ In this section, we'll connect to the `Devnet` network. `Devnet` is a network de
 and experimintation of developers and holds no real value. Users can reach out on Discord if they would like to request a prefunded account.
 
 Only use the `Devnet` network if you are a developer and building on top of the Mina protocol. If you are interested in running a node, please connect
-to [Zenith](./connecting-zenith) instead.
-
-Please note that `Devnet` will be the final release that will be referencing the `mina` executable and `~/.mina-config` config directory
-as `mina`. Future releases will refer to the executable and config directory as `mina` and `~/.mina-config` respectively. We recommend users to take time to update
-any scripts and tools that use the old `mina` name to now use the new `mina` name as this will be a breaking change in future releases.
+to [FinalFinal2](/docs/connecting) instead.
 
 ## Update your software
 

--- a/src/components/FooterLinks.re
+++ b/src/components/FooterLinks.re
@@ -58,7 +58,7 @@ let make = () => {
       <Next.Link href="/docs/getting-started">
         <a className=Styles.linkStyle> {React.string("Documentation")} </a>
       </Next.Link>
-      <Next.Link href="/docs/node-operator">
+      <Next.Link href="/node-operator">
         <a className=Styles.linkStyle> {React.string("Run a Node")} </a>
       </Next.Link>
       <Next.Link href="/docs">

--- a/src/pages/Grants.re
+++ b/src/pages/Grants.re
@@ -506,27 +506,6 @@ module ProtocolProjects = {
             buttonUrl=Constants.projectGrantApplication
           />
           <Spacer height=3. />
-          <Project.ThreeColumn
-            title="Alternative Client Implementation (e.g. Rust)"
-            rows=[|
-              {
-                firstColumn: {
-                  title: "Allocation",
-                  copy: {js|Minimum of 400,000 Mina tokens|js},
-                },
-                secondColumn: {
-                  title: "Project Type",
-                  copy: {js|Open source|js},
-                },
-                thirdColumn: {
-                  title: "Overview",
-                  copy: {js|Enable Mina nodes to parse and verify the Mina transactions, its smart contracts and everything related. Provide an interfaces to create transactions, product blocks, and create snarks in Mina.|js},
-                },
-              },
-            |]
-            buttonUrl=Constants.projectGrantApplication
-          />
-          <Spacer height=3. />
         </Section>
     </div>;
 };


### PR DESCRIPTION
Removes the rust client grant from `/grants` and fixes the `Run a Node` footer link and a couple of links on the Devnet page.