### PR TITLE
Docs: Renamed Coda executables to Mina

### DIFF
--- a/pages/docs/advanced/archive-node.mdx
+++ b/pages/docs/advanced/archive-node.mdx
@@ -16,7 +16,7 @@ Let's get started by installing what we need.
 
 ## Installation
 
-1. Install the latest version of mina. If you haven't upgraded to the latest version of the daemon, head [back to the docs](/docs/getting-started) to get the latest version. You can run ```coda -help``` to check if the installation succeeded.
+1. Install the latest version of mina. If you haven't upgraded to the latest version of the daemon, head [back to the docs](/docs/getting-started) to get the latest version. You can run ```mina -help``` to check if the installation succeeded.
 2. Install [Postgres](https://www.postgresql.org/download/).
 3. Install the archive node package. 
 
@@ -64,7 +64,7 @@ coda-archive \
 
 4. Start the daemon, connecting it to the archive process that we just started on port 3086. If you want to connect to an archive process on another machine, you can specify a hostname as well, like `localhost:3086`.
 ```
-coda daemon \
+mina daemon \
     .....
   -archive-address 3086\
 ```

--- a/pages/docs/advanced/client-sdk.mdx
+++ b/pages/docs/advanced/client-sdk.mdx
@@ -39,9 +39,9 @@ Creating a key pair is simple with our client SDK. See the snippet below to see 
 
 ### NodeJS:
 ```javascript
-const CodaSDK = require("@o1labs/client-sdk");
+const MinaSDK = require("@o1labs/client-sdk");
 
-let keys = CodaSDK.genKeys();
+let keys = MinaSDK.genKeys();
 console.log(`Public key: ${keys.publicKey}`)
 console.log(`Private key: ${keys.privateKey}`)
 ```
@@ -63,7 +63,7 @@ Never give out your private key and make sure they are stored safely. If you los
 
 Please note that there are differences in key pair format between what the Mina client expects and what the client SDK generates. 
 When the client SDK is used to generate a key pair, the key pair output returned are strings that aren't directly importable into our Mina client. 
-For this, we will have to use the `coda advanced wrap-key` tool to format our key pair strings into a format that is directly importable to our client.
+For this, we will have to use the `mina advanced wrap-key` tool to format our key pair strings into a format that is directly importable to our client.
 
 Accomplishing this takes only a few short steps.
 
@@ -90,10 +90,10 @@ echo 'YOUR-PRIVATE_KEY' > ~/keys/my-wallet
 chmod 600 ~/keys/my-wallet
 ```
 
-5. Use the `coda advanced wrap-key` tool to format your key pair into an importable format for the Mina client. Please note that using `coda advanced wrap-key` will force you to reset your password on your private key.
+5. Use the `mina advanced wrap-key` tool to format your key pair into an importable format for the Mina client. Please note that using `mina advanced wrap-key` will force you to reset your password on your private key.
 
 ```
-coda advanced wrap-key -privkey-path ~/keys/my-wallet
+mina advanced wrap-key -privkey-path ~/keys/my-wallet
 ```
 
 You will be prompted for a new password, as shown below.
@@ -120,10 +120,10 @@ chmod 600 ~/keys/my-wallet
 7. Finally, we can import the account created by the client SDK into the client.
 
 ```
-coda accounts import -privkey-path ~/keys/my-wallet
+mina accounts import -privkey-path ~/keys/my-wallet
 ```
 
-You will be prompted for the password you entered when the account was created with `coda advanced wrap-key`.
+You will be prompted for the password you entered when the account was created with `mina advanced wrap-key`.
 
 The response from this command will look like this: 
 ```

--- a/pages/docs/advanced/hard-fork.mdx
+++ b/pages/docs/advanced/hard-fork.mdx
@@ -21,10 +21,10 @@ Participating in a hard fork is incredibly simple. Once a hard fork is announced
 
 When the hard fork version is announced, first shut off any node(s) you have running.
 
-Next, remove your `.coda-config` folder since the fork will require syncing from scratch.
+Next, remove your `.mina-config` folder since the fork will require syncing from scratch.
 
 ```
-rm -rf ~/.coda-config
+rm -rf ~/.mina-config
 ```
 
 Now you can follow the instructions on the [Connecting to the Network](/docs/connecting) to install the latest version of the daemon.

--- a/pages/docs/advanced/hot-cold-block-production.mdx
+++ b/pages/docs/advanced/hot-cold-block-production.mdx
@@ -35,7 +35,7 @@ Your cold wallet must be present in the consensus ledger before its stake can be
 
 ### Delegate your cold wallet to your hot wallet
 
-Next, ensure that you have delegated your cold account to your hot one. If you've set up your account to delegate to the correct spot in the genesis ledger, then no further action is needed. Otherwise you can delegate by using the `coda client delegate-stake` command if your key was generated on a computer. Otherwise, see the delegate instructions on the [Mina ledger README](https://github.com/jspada/ledger-app-mina/tree/v1.0.0-beta.2) to learn more.
+Next, ensure that you have delegated your cold account to your hot one. If you've set up your account to delegate to the correct spot in the genesis ledger, then no further action is needed. Otherwise you can delegate by using the `mina client delegate-stake` command if your key was generated on a computer. Otherwise, see the delegate instructions on the [Mina ledger README](https://github.com/jspada/ledger-app-mina/tree/v1.0.0-beta.2) to learn more.
 
 ## Block Production
 

--- a/pages/docs/advanced/seed-peers.mdx
+++ b/pages/docs/advanced/seed-peers.mdx
@@ -23,7 +23,7 @@ Secondly, you'll need to select the port that your node is running on. By defaul
 Thirdly, you'll want to pregenerate your libp2p keypair -- this is used to identify you on the gossip network. To do so:
 
 ```
-coda advanced generate-libp2p-keypair
+mina advanced generate-libp2p-keypair
 ```
 
 This will generate a libp2p keypair on your machine.

--- a/pages/docs/advanced/staking-service-guidelines.mdx
+++ b/pages/docs/advanced/staking-service-guidelines.mdx
@@ -15,7 +15,7 @@ The coinbase reward for producing a block is 720 tokens. However, some accounts 
 
 In order to compute odds of winning a block for a given epoch, or to retroactively compute the coinbase reward a given account would receive, you need to have the staking ledger from that epoch. Mina daemons only keep around the staking ledger for the current epoch and the staking ledger for the next epoch, so if you want to capture a staking ledger for an epoch, you need to do it before or during that epoch.
 
-The `coda ledger export` command can be used to export ledgers from a running daemon. It takes, as an argument, an identifier of the ledger you wish to export. The table below describes what each of these identifiers represent.
+The `mina ledger export` command can be used to export ledgers from a running daemon. It takes, as an argument, an identifier of the ledger you wish to export. The table below describes what each of these identifiers represent.
 
 | Identifier           | Description                                                     |
 |----------------------|-----------------------------------------------------------------|
@@ -28,7 +28,7 @@ The `coda ledger export` command can be used to export ledgers from a running da
 
 In order to ensure you always have each staking ledger available for use after epochs have expired, we recommend exporting the staking-epoch-ledger every $\dfrac{7140\times3}{60} = 357$ hours (there are $7140$ slots in an epoch, and each slot is $3$ minutes long).
 
-By default, ledgers are exported as json data. See `coda ledger export -help` for documentation of flags which will enable other formats. When output as json, the ledger will be represented as an array of account objects. Below is an example of what an account object in json looks like.
+By default, ledgers are exported as json data. See `mina ledger export -help` for documentation of flags which will enable other formats. When output as json, the ledger will be represented as an array of account objects. Below is an example of what an account object in json looks like.
 
 ```json
 {
@@ -53,7 +53,7 @@ By default, ledgers are exported as json data. See `coda ledger export -help` fo
 For a running staking service, you are interested in the accounts which you control and the accounts which are staking to accounts you control. As an example, if we only had one account in our staking service, we could grab all the accounts we are intersted in for a ledger using a command like:
 
 ```sh
-coda ledger export staking-epoch-ledger | jq "$(cat <<EOF
+mina ledger export staking-epoch-ledger | jq "$(cat <<EOF
   .[] | \
   select( \
     .pk == "B62qjwvvHoM9RVt9onMpSMS5rFzhy3jjXY1Q9JU7HyHW4oWFEbWpghe" or \

--- a/pages/docs/developers/client-sdk.mdx
+++ b/pages/docs/developers/client-sdk.mdx
@@ -33,15 +33,15 @@ npm install --save @o1labs/client-sdk
 ### Typescript
 
 ```
-import * as CodaSDK from "@o1labs/client-sdk";
+import * as MinaSDK from "@o1labs/client-sdk";
 
-let keys = CodaSDK.genKeys();
-let signed = CodaSDK.signMessage("hello", keys);
-if (CodaSDK.verifyMessage(signed)) {
+let keys = MinaSDK.genKeys();
+let signed = MinaSDK.signMessage("hello", keys);
+if (MinaSDK.verifyMessage(signed)) {
     console.log("Message was verified successfully")
 };
 
-let signedPayment = CodaSDK.signPayment({
+let signedPayment = MinaSDK.signPayment({
     to: keys.publicKey,
     from: keys.publicKey,
     amount: 1,
@@ -53,15 +53,15 @@ let signedPayment = CodaSDK.signPayment({
 ### NodeJS
 
 ```
-const CodaSDK = require("@o1labs/client-sdk");
+const MinaSDK = require("@o1labs/client-sdk");
 
-let keys = CodaSDK.genKeys();
-let signed = CodaSDK.signMessage("hello", keys);
-if (CodaSDK.verifyMessage(signed)) {
+let keys = MinaSDK.genKeys();
+let signed = MinaSDK.signMessage("hello", keys);
+if (MinaSDK.verifyMessage(signed)) {
     console.log("Message was verified successfully")
 };
 
-let signedPayment = CodaSDK.signPayment({
+let signedPayment = MinaSDK.signPayment({
     to: keys.publicKey,
     from: keys.publicKey,
     amount: 1,
@@ -77,15 +77,15 @@ let signedPayment = CodaSDK.signPayment({
 * Build dependencies: `yarn bsb -make-world`
 
 ```
-module CodaSDK = O1labsClientSdk.CodaSDK;
+module MinaSDK = O1labsClientSdk.CodaSDK;
 
-let keys = CodaSDK.genKeys();
-let signed = CodaSDK.signMessage(. "hello", keys);
-if (CodaSDK.verifyMessage(. signed)) {
+let keys = MinaSDK.genKeys();
+let signed = MinaSDK.signMessage(. "hello", keys);
+if (MinaSDK.verifyMessage(. signed)) {
   Js.log("Message was verified successfully");
 };
 
-let signedPayment = CodaSDK.signPayment({
+let signedPayment = MinaSDK.signPayment({
     to_: keys.publicKey,
     from: keys.publicKey,
     amount: "1",
@@ -96,6 +96,6 @@ let signedPayment = CodaSDK.signPayment({
 
 <Alert>
 
-When generating transactions, you will need to specify the account nonce. This is available for an account via the CLI using `coda advanced get-nonce -address <PUBLIC_KEY>` or using [GraphQL](/docs/developers/graphql-api).
+When generating transactions, you will need to specify the account nonce. This is available for an account via the CLI using `mina advanced get-nonce -address <PUBLIC_KEY>` or using [GraphQL](/docs/developers/graphql-api).
 
 </Alert>


### PR DESCRIPTION
Went through the docs and searched for references using the coda binary and replaced it with mina. This only applies to the executable and not the env variables or some of the tools that have not been renamed.

Additionally updated references to the client_sdk examples. Tested that it runs properly by spinning up a node project and copying the example code.