### PR TITLE
sidecar-docs-fix One more pass at the sidecar docs incorporating user feedback

### DIFF
--- a/pages/docs/advanced/node-status.mdx
+++ b/pages/docs/advanced/node-status.mdx
@@ -30,7 +30,7 @@ We will need to update the config file with the correct parameters. So use your 
 ```
 {
   "uploadURL": "https://us-central1-mina-mainnet-303900.cloudfunctions.net/block-producer-stats-ingest/?token=72941420a9595e1f4006e2f3565881b5",
-  "nodeURL": "http://localhost:3095"
+  "nodeURL": "http://127.0.0.1:3095"
 }
 ```
 
@@ -44,14 +44,14 @@ docker pull minaprotocol/mina-bp-stats-sidecar:latest
 
 Next we will need to setup the config file, for this tutorial we will assume you are on a Linux based host system.
 
+
+We will need to create a config file with the correct parameters. So use your prefered editor to replace the contents of `~/mina-sidecar-config.json` with the following:
+
 ```
-cd $HOME && touch ./mina-sidecar-config.json
-cat << EOF > ./mina-sidecar-config.json
 {
   "uploadURL": "https://us-central1-mina-mainnet-303900.cloudfunctions.net/block-producer-stats-ingest/?token=72941420a9595e1f4006e2f3565881b5",
   "nodeURL": "http://mina:3095"
 }
-EOF
 ```
 
 We will pass this file into the Docker container in the next step.

--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -45,6 +45,8 @@ Run the following command to start up a Mina node instance and connect to the li
 mina daemon --generate-genesis-proof true --peer-list-url https://storage.googleapis.com/mina-seed-lists/mainnet_seeds.txt
 ```
 
+If you have a key with stake and would like to produce blocks, also provide `--block-producer-key ~/keys/my-wallet`, replacing `~/keys/my-wallet` with the path to your private key if not the default.
+
 The `-peer-list` argument specified above refer to the seed peer address - this is the initial peer we will connect to on the network. Since Mina is a [peer-to-peer](/docs/glossary#peer-to-peer) protocol, there is no single centralized server we rely on.
 
 See [here](/docs/troubleshooting) for common issues when first running a node.


### PR DESCRIPTION
Improve debian sidecar docs for reliability and add a note about --block-producer-key in the main connecting docs