### PR TITLE
Update for extract blocks

### DIFF
--- a/pages/docs/advanced/archive-redundancy.mdx
+++ b/pages/docs/advanced/archive-redundancy.mdx
@@ -3,7 +3,7 @@ export default Page({title: "Archive Redundancy"});
 
 # Archive Redundancy
 
-Archive data is critical for applications that require historical lookup. On the protocol side, archive data is important for disaster recovery in that it is needed to reconstruct a certain state. To that end, having a single [archive node setup](/docs/archive-node) might not be sufficient. If the daemon that sends blocks to the archive process or if the archive process itself fails for some reason, there can be missing blocks in the database. To minimize the risk of archive data loss there are a few redundancy techniques that can be employed.  
+Archive data is critical for applications that require historical lookup. On the protocol side, archive data is important for disaster recovery in that it is needed to reconstruct a certain state. To that end, having a single [archive node setup](/docs/archive-node) might not be sufficient. If the daemon that sends blocks to the archive process or if the archive process itself fails for some reason, there can be missing blocks in the database. To minimize the risk of archive data loss there are a few redundancy techniques that can be employed.
 
 A single archive node setup has a daemon sending blocks to an archive process which writes them to the database.
 
@@ -54,11 +54,13 @@ The daemon also logs the block data if the flag `-log-precomputed-blocks` is pas
 
 ### Generate block data from another archive database
 
-From a fully synced archive database, one can generate block data for each block using the `mina-missing-subchain` tool. 
+From a fully synced archive database, one can generate block data for each block using the `mina-extract-blocks` tool.
 
 The tool takes an `--archive-uri`, an `--end-state-hash`, and an optional --start-state-hash and writes all the blocks in the chain starting from start-state-hash and ending at end-state-hash (including start and end).
 
-If only the end hash is provided, then it generates blocks starting with the unparented block closest to the end block. This would be the genesis block if there are no missing blocks in between. The tool generates a file with name `<protocol-state-hash>.json` for each block. The block data in these files are called extensional blocks. Since these are generated from the database, they would have only the data stored in the archive database and would not contain any other information pertaining to a block (for example, blockchain snark) that the precomputed blocks would have and therefore, can only be used to restore blocks in the archive database.
+If only the end hash is provided, then the tool generates blocks starting with the unparented block closest to the end block. This would be the genesis block if there are no missing blocks in between. The tool generates a file with name `<protocol-state-hash>.json` for each block. The block data in these files are called extensional blocks. Since these are generated from the database, they would have only the data stored in the archive database and would not contain any other information pertaining to a block (for example, blockchain snark) that the precomputed blocks would have and therefore, can only be used to restore blocks in the archive database.
+
+Alternatively, instead of specifying state hashes, you can provide the flag `--all-blocks`, and the tool will write out all blocks contained in the database.
 
 ## Identifying missing blocks
 


### PR DESCRIPTION
Change `mina-missing-subchain` to `mina-extract-blocks`, to reflect the change in https://github.com/MinaProtocol/mina/pull/8343 (not yet merged, but soon!). Mention the new `--all-blocks` flag.