### PR TITLE
Add command to download peer list to peers.txt

### DIFF
--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -68,6 +68,12 @@ EXTRA_FLAGS=" --file-log-level Debug"
 
 You can add extra flags later to `EXTRA_FLAGS` as you see fit.
 
+Mina will be looking for its peers in a file called `~/peers.txt`, so run the following command to create it:
+
+```
+curl https://storage.googleapis.com/mina-seed-lists/mainnet_seeds.txt > ~/peers.txt
+```
+
 Then run the following commands to start up a Mina node instance and connect to the live network:
 
 ```


### PR DESCRIPTION
When following the instructions (starting from scratch), the peers file `~/peers.txt` will not have been created while the Mina daemon will be looking for it. This adds a step to the documentation page so that happens!

This PR should close #170.