### PR TITLE
Fixed 'undefined' in Carousel cards

### DIFF
--- a/src/ContentType.re
+++ b/src/ContentType.re
@@ -120,7 +120,7 @@ module GenesisProfile = {
   type t = {
     name: string,
     image: Image.entry,
-    quote: string,
+    quote: option(string),
     memberLocation: string,
     twitter: option(string),
     github: option(string),
@@ -139,7 +139,7 @@ module TeamProfile = {
     image: Image.entry,
     title: string,
     bio: string,
-    quote: string,
+    quote: option(string),
     twitter: option(string),
     github: option(string),
     linkedin: option(string),

--- a/src/components/CarouselCards.re
+++ b/src/components/CarouselCards.re
@@ -143,7 +143,11 @@ module GenesisMemberCard = {
         </p>
         <div className={Styles.quoteSection(dark)}>
           <Rule />
-          <p className=Styles.quote> {React.string({j|"$(quote)"|j})} </p>
+          {switch (quote) {
+           | Some(q) =>
+             <p className=Styles.quote> {React.string({j|"$(q)"|j})} </p>
+           | None => React.null
+           }}
           <Rule />
         </div>
         <div className=Styles.socials>
@@ -256,7 +260,11 @@ module TeamMemberCard = {
         <p className={Styles.memberTitle(dark)}> {React.string(title)} </p>
         <div className={Styles.quoteSection(dark)}>
           <Rule />
-          <p className=Styles.quote> {React.string({j|"$(quote)"|j})} </p>
+          {switch (quote) {
+           | Some(q) =>
+             <p className=Styles.quote> {React.string({j|"$(q)"|j})} </p>
+           | None => React.null
+           }}
           <Rule />
         </div>
         <div className=Styles.socials>


### PR DESCRIPTION
'Undefined' was showing up as a message for Genesis and Team members who didn't have a defined quote in Contentful.
Made the quote field an option(string) type in ContentTypes.TeamMember and ContentTypes.GenesisMember. Added a switch statement that checks for a quote field and conditionally displays a message now.