### PR TITLE
Removed chmod 600 ~/.mina-env line

### DIFF
--- a/pages/docs/connecting.mdx
+++ b/pages/docs/connecting.mdx
@@ -58,8 +58,6 @@ CODA_PRIVKEY_PASS="private key password"
 EXTRA_FLAGS=" --file-log-level Debug"
 ```
 
-Afterwards, run `chmod 600 ~/.mina-env` to secure this file.
-
 You can add extra flags later to `EXTRA_FLAGS` as you see fit.
 
 Mina will be looking for its peers in a file called `~/peers.txt`, so run the following command to create it:


### PR DESCRIPTION
If you run `chmod 600 ~/.mina-env` to secure this file and later try to start the service it fails to load with the following error:

```
mina.service: Failed to load environment files: Permission denied
minan01 systemd[1376]: mina.service: Failed to run 'start' task: Permission denied
minan01 systemd[1376]: mina.service: Failed with result 'resources'.
minan01 systemd[1376]: Failed to start Mina Daemon Service.
~$ systemctl --user start mina
Job for mina.service failed because of unavailable resources or another system error.
See "systemctl --user status mina.service" and "journalctl --user -xe" for details.
```

Several people have encountered this error including me. Either we need to mention under what condition it will work or remove this line as new comers are having issues connecting.