### PR TITLE
Installation instructions

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -58,7 +58,7 @@ If you installed `mina` from a previous release, you'll need to upgrade it so th
 Add the Mina Debian repo and install:
 
 ```
-echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/mina.list
+echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
 sudo apt-get install -y curl unzip mina-mainnet=1.1.5-a42bdee
 ```


### PR DESCRIPTION
The updated line will work without user having to manually substitute 'release' with their release name. It is preferable to be this way or the user has to be instructed to manually replace 'release' with their release of Debian / Ubuntu. You can read more about adding apt repositories [here][1].

[1]: https://linuxize.com/post/how-to-add-apt-repository-in-ubuntu/